### PR TITLE
chore: add *.tgz to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,10 @@ Thumbs.db
 logs/
 traces/
 header.txt
+
+# Helm chart tarballs
+*.tgz
+
 # Tourist Scheduling System generated artifacts
 tourist_scheduling_system/*.log
 tourist_scheduling_system/ui_agent_ports.json


### PR DESCRIPTION
## Summary

Add `*.tgz` pattern to `.gitignore` to ignore Helm chart tarballs and other compressed archives.

This prevents accidentally committing downloaded Helm charts like `slim-v0.7.0.tgz`, `dir-v0.5.6.tgz`, etc.