### PR TITLE
fix: add proxy env vars to scheduler and UI agent K8s manifests

### DIFF
--- a/tourist_scheduling_system/deploy/k8s/scheduler-agent.yaml
+++ b/tourist_scheduling_system/deploy/k8s/scheduler-agent.yaml
@@ -105,6 +105,43 @@ spec:
                   name: agent-config
                   key: SCHEDULER_EXTERNAL_URL
                   optional: true
+            # Proxy configuration
+            - name: HTTP_PROXY
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: HTTP_PROXY
+                  optional: true
+            - name: HTTPS_PROXY
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: HTTPS_PROXY
+                  optional: true
+            - name: NO_PROXY
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: NO_PROXY
+                  optional: true
+            - name: http_proxy
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: HTTP_PROXY
+                  optional: true
+            - name: https_proxy
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: HTTPS_PROXY
+                  optional: true
+            - name: no_proxy
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: NO_PROXY
+                  optional: true
           resources:
             requests:
               memory: "256Mi"

--- a/tourist_scheduling_system/deploy/k8s/ui-agent.yaml
+++ b/tourist_scheduling_system/deploy/k8s/ui-agent.yaml
@@ -79,6 +79,43 @@ spec:
                   name: agent-config
                   key: SCHEDULER_URL
                   optional: true
+            # Proxy configuration
+            - name: HTTP_PROXY
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: HTTP_PROXY
+                  optional: true
+            - name: HTTPS_PROXY
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: HTTPS_PROXY
+                  optional: true
+            - name: NO_PROXY
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: NO_PROXY
+                  optional: true
+            - name: http_proxy
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: HTTP_PROXY
+                  optional: true
+            - name: https_proxy
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: HTTPS_PROXY
+                  optional: true
+            - name: no_proxy
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: NO_PROXY
+                  optional: true
           resources:
             requests:
               memory: "512Mi"


### PR DESCRIPTION
Add HTTP_PROXY, HTTPS_PROXY, NO_PROXY environment variables (both uppercase and lowercase) to scheduler-agent.yaml and ui-agent.yaml for environments that require proxy configuration to access external APIs like Azure OpenAI.

The proxy values are read from the agent-config configmap.

## Changes
- Added proxy env vars to `deploy/k8s/scheduler-agent.yaml`
- Added proxy env vars to `deploy/k8s/ui-agent.yaml`

## Testing
Tested in K8s deployment - scheduler and UI agents can now reach Azure OpenAI through the proxy.