### PR TITLE
feat(tourist-scheduling): Add SLIM transport support for ADK agents

### DIFF
--- a/tourist_scheduling_system/containers/scheduler/Dockerfile
+++ b/tourist_scheduling_system/containers/scheduler/Dockerfile
@@ -57,4 +57,5 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 EXPOSE 10000
 
 # Run the scheduler agent
-CMD ["sh", "-c", "python main.py --host 0.0.0.0 --port $PORT --mode a2a"]
+# TRANSPORT_MODE can be 'http' or 'slim' (default: http)
+CMD ["sh", "-c", "python main.py --host 0.0.0.0 --port $PORT --mode a2a --transport ${TRANSPORT_MODE:-http}"]

--- a/tourist_scheduling_system/deploy/k8s/configmap.yaml
+++ b/tourist_scheduling_system/deploy/k8s/configmap.yaml
@@ -29,6 +29,11 @@ data:
   # SLIM configuration (used when TRANSPORT_MODE=slim)
   SLIM_GATEWAY_HOST: "${SLIM_GATEWAY_HOST}"
   SLIM_GATEWAY_PORT: "${SLIM_GATEWAY_PORT}"
+  SLIM_SHARED_SECRET: "${SLIM_SHARED_SECRET}"
+  SLIM_TLS_INSECURE: "true"
+
+  # SLIM topic IDs (for agent routing)
+  SCHEDULER_SLIM_TOPIC: "agntcy/tourist_scheduling/scheduler"
 
   # Service URLs
   SCHEDULER_URL: "${SCHEDULER_URL}"

--- a/tourist_scheduling_system/deploy/k8s/guide-agent.yaml
+++ b/tourist_scheduling_system/deploy/k8s/guide-agent.yaml
@@ -80,6 +80,24 @@ spec:
                   name: agent-config
                   key: SLIM_GATEWAY_PORT
                   optional: true
+            - name: SLIM_SHARED_SECRET
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SLIM_SHARED_SECRET
+                  optional: true
+            - name: SLIM_TLS_INSECURE
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SLIM_TLS_INSECURE
+                  optional: true
+            - name: SCHEDULER_SLIM_TOPIC
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SCHEDULER_SLIM_TOPIC
+                  optional: true
           args:
             - "--guide-id=g1"
             - "--categories=culture,history,food"
@@ -160,6 +178,24 @@ spec:
                 configMapKeyRef:
                   name: agent-config
                   key: SLIM_GATEWAY_PORT
+                  optional: true
+            - name: SLIM_SHARED_SECRET
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SLIM_SHARED_SECRET
+                  optional: true
+            - name: SLIM_TLS_INSECURE
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SLIM_TLS_INSECURE
+                  optional: true
+            - name: SCHEDULER_SLIM_TOPIC
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SCHEDULER_SLIM_TOPIC
                   optional: true
           args:
             - "--guide-id=g2"

--- a/tourist_scheduling_system/deploy/k8s/scheduler-agent.yaml
+++ b/tourist_scheduling_system/deploy/k8s/scheduler-agent.yaml
@@ -99,6 +99,18 @@ spec:
                   name: agent-config
                   key: SLIM_GATEWAY_PORT
                   optional: true
+            - name: SLIM_SHARED_SECRET
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SLIM_SHARED_SECRET
+                  optional: true
+            - name: SLIM_TLS_INSECURE
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SLIM_TLS_INSECURE
+                  optional: true
             - name: SCHEDULER_EXTERNAL_URL
               valueFrom:
                 configMapKeyRef:

--- a/tourist_scheduling_system/deploy/k8s/tourist-agent.yaml
+++ b/tourist_scheduling_system/deploy/k8s/tourist-agent.yaml
@@ -80,6 +80,24 @@ spec:
                   name: agent-config
                   key: SLIM_GATEWAY_PORT
                   optional: true
+            - name: SLIM_SHARED_SECRET
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SLIM_SHARED_SECRET
+                  optional: true
+            - name: SLIM_TLS_INSECURE
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SLIM_TLS_INSECURE
+                  optional: true
+            - name: SCHEDULER_SLIM_TOPIC
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SCHEDULER_SLIM_TOPIC
+                  optional: true
           args:
             - "--tourist-id=t1"
             - "--preferences=culture,history"
@@ -159,6 +177,24 @@ spec:
                 configMapKeyRef:
                   name: agent-config
                   key: SLIM_GATEWAY_PORT
+                  optional: true
+            - name: SLIM_SHARED_SECRET
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SLIM_SHARED_SECRET
+                  optional: true
+            - name: SLIM_TLS_INSECURE
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SLIM_TLS_INSECURE
+                  optional: true
+            - name: SCHEDULER_SLIM_TOPIC
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: SCHEDULER_SLIM_TOPIC
                   optional: true
           args:
             - "--tourist-id=t2"

--- a/tourist_scheduling_system/src/agents/guide_agent.py
+++ b/tourist_scheduling_system/src/agents/guide_agent.py
@@ -12,6 +12,7 @@ This agent can:
 3. Manage its availability and specialties
 
 Uses ADK's RemoteA2aAgent to communicate with the scheduler's A2A endpoint.
+Supports both HTTP and SLIM transport based on TRANSPORT_MODE env var.
 """
 
 import asyncio
@@ -33,6 +34,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def get_transport_mode() -> str:
+    """Get the configured transport mode (http or slim)."""
+    return os.environ.get("TRANSPORT_MODE", "http").lower()
+
+
 def create_guide_offer_message(
     guide_id: str,
     categories: list[str],
@@ -51,19 +57,21 @@ def create_guide_offer_message(
 - Max group size: {max_group_size}"""
 
 
-def create_guide_agent(
+async def create_guide_agent(
     guide_id: str,
     scheduler_url: str = "http://localhost:10000",
+    a2a_client_factory=None,
 ):
     """
     Create an ADK-based guide agent.
 
     The guide agent uses RemoteA2aAgent as a sub-agent to communicate
-    with the scheduler.
+    with the scheduler. Supports both HTTP and SLIM transport.
 
     Args:
         guide_id: Unique identifier for this guide
-        scheduler_url: URL of the scheduler's A2A endpoint
+        scheduler_url: URL of the scheduler's A2A endpoint (for HTTP)
+        a2a_client_factory: Optional A2A client factory (for SLIM transport)
 
     Returns:
         Configured LlmAgent for the guide
@@ -73,15 +81,37 @@ def create_guide_agent(
     from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
     from google.adk.models.lite_llm import LiteLlm
 
-    # Create remote scheduler agent reference
-    # The agent_card parameter is a URL to the scheduler's agent card
-    # Use new endpoint path (/.well-known/agent-card.json) instead of deprecated /.well-known/agent.json
-    agent_card_url = f"{scheduler_url.rstrip('/')}/.well-known/agent-card.json"
-    scheduler_remote = RemoteA2aAgent(
-        name="scheduler",
-        description="The tourist scheduling coordinator that handles guide offers",
-        agent_card=agent_card_url,
-    )
+    transport_mode = get_transport_mode()
+    logger.info(f"[Guide {guide_id}] Creating agent with transport mode: {transport_mode}")
+
+    # Create remote scheduler agent reference based on transport mode
+    if transport_mode == "slim" and a2a_client_factory is not None:
+        # For SLIM transport, use minimal agent card with slimrpc transport
+        from core.slim_transport import minimal_slim_agent_card
+
+        # The scheduler's SLIM topic (must match scheduler's local_id)
+        scheduler_topic = os.environ.get(
+            "SCHEDULER_SLIM_TOPIC",
+            "agntcy/tourist_scheduling/scheduler"
+        )
+        agent_card = minimal_slim_agent_card(scheduler_topic)
+
+        scheduler_remote = RemoteA2aAgent(
+            name="scheduler",
+            description="The tourist scheduling coordinator that handles guide offers",
+            agent_card=agent_card,
+            a2a_client_factory=a2a_client_factory,
+        )
+        logger.info(f"[Guide {guide_id}] Using SLIM transport to scheduler topic: {scheduler_topic}")
+    else:
+        # HTTP transport - use URL-based agent card
+        agent_card_url = f"{scheduler_url.rstrip('/')}/.well-known/agent-card.json"
+        scheduler_remote = RemoteA2aAgent(
+            name="scheduler",
+            description="The tourist scheduling coordinator that handles guide offers",
+            agent_card=agent_card_url,
+        )
+        logger.info(f"[Guide {guide_id}] Using HTTP transport to scheduler: {agent_card_url}")
 
     # Get model configuration from environment
     # Supports Azure OpenAI via LiteLLM
@@ -142,11 +172,47 @@ async def run_guide_agent(
     # Import ADK runner at runtime
     from google.adk.runners import InMemoryRunner
 
-    print(f"[Guide {guide_id}] Starting with ADK...")
-    print(f"[Guide {guide_id}] Connecting to scheduler at {scheduler_url}")
+    transport_mode = get_transport_mode()
+    print(f"[Guide {guide_id}] Starting with ADK (transport: {transport_mode})...")
+
+    # Set up SLIM client factory if using SLIM transport
+    a2a_client_factory = None
+    if transport_mode == "slim":
+        try:
+            from core.slim_transport import (
+                create_slim_client_factory,
+                config_from_env,
+                SLIMConfig,
+            )
+
+            # Create SLIM config for this guide agent
+            # Override local_id to be unique for this guide
+            base_config = config_from_env()
+            guide_local_id = f"agntcy/tourist_scheduling/guide_{guide_id}"
+
+            config = SLIMConfig(
+                endpoint=base_config.endpoint,
+                local_id=guide_local_id,
+                shared_secret=base_config.shared_secret,
+                tls_insecure=base_config.tls_insecure,
+            )
+
+            print(f"[Guide {guide_id}] Connecting to SLIM at {config.endpoint}")
+            print(f"[Guide {guide_id}] Using SLIM ID: {config.local_id}")
+
+            a2a_client_factory = await create_slim_client_factory(config)
+            print(f"[Guide {guide_id}] SLIM client factory created successfully")
+        except ImportError as e:
+            print(f"[Guide {guide_id}] SLIM not available, falling back to HTTP: {e}")
+            transport_mode = "http"
+        except Exception as e:
+            print(f"[Guide {guide_id}] Failed to create SLIM client: {e}")
+            raise
+    else:
+        print(f"[Guide {guide_id}] Connecting to scheduler at {scheduler_url}")
 
     # Create the guide agent
-    agent = create_guide_agent(guide_id, scheduler_url)
+    agent = await create_guide_agent(guide_id, scheduler_url, a2a_client_factory)
     runner = InMemoryRunner(agent=agent)
 
     # Create offer message

--- a/tourist_scheduling_system/src/agents/scheduler_agent.py
+++ b/tourist_scheduling_system/src/agents/scheduler_agent.py
@@ -302,8 +302,9 @@ def main(mode: str, port: int, host: str, transport: str, slim_endpoint: str, sl
             slim_config.endpoint = slim_endpoint
         if slim_local_id:
             slim_config.local_id = slim_local_id
-        else:
-            slim_config.local_id = "agntcy/tourist_scheduling/adk_scheduler"
+        elif slim_config.local_id == "agntcy/tourist_scheduling/agent":
+            # Use consistent default that matches what clients expect
+            slim_config.local_id = "agntcy/tourist_scheduling/scheduler"
 
         logger.info(f"[ADK Scheduler] Starting with SLIM transport")
         logger.info(f"[ADK Scheduler] SLIM endpoint: {slim_config.endpoint}")

--- a/tourist_scheduling_system/src/core/slim_transport.py
+++ b/tourist_scheduling_system/src/core/slim_transport.py
@@ -480,14 +480,29 @@ def config_from_env(prefix: str = "") -> SLIMConfig:
 
     Returns:
         SLIMConfig populated from environment
+
+    Environment Variables:
+        SLIM_ENDPOINT: Full endpoint URL (e.g., "http://slim-node:46357")
+        SLIM_GATEWAY_HOST: Host name for SLIM gateway (alternative to SLIM_ENDPOINT)
+        SLIM_GATEWAY_PORT: Port for SLIM gateway (used with SLIM_GATEWAY_HOST)
+        SLIM_LOCAL_ID: Local agent identifier
+        SLIM_SHARED_SECRET: MLS shared secret for encryption
+        SLIM_TLS_INSECURE: Whether to skip TLS verification
     """
     import os
 
     def get_env(key: str, default: str) -> str:
         return os.environ.get(f"{prefix}{key}", os.environ.get(key, default))
 
+    # Construct endpoint from SLIM_GATEWAY_HOST and SLIM_GATEWAY_PORT if SLIM_ENDPOINT not set
+    endpoint = get_env("SLIM_ENDPOINT", "")
+    if not endpoint:
+        gateway_host = get_env("SLIM_GATEWAY_HOST", "localhost")
+        gateway_port = get_env("SLIM_GATEWAY_PORT", "46357")
+        endpoint = f"http://{gateway_host}:{gateway_port}"
+
     return SLIMConfig(
-        endpoint=get_env("SLIM_ENDPOINT", "http://localhost:46357"),
+        endpoint=endpoint,
         local_id=get_env("SLIM_LOCAL_ID", "agntcy/tourist_scheduling/agent"),
         shared_secret=get_env("SLIM_SHARED_SECRET", "tourist-scheduling-demo-secret-key-32"),
         tls_insecure=get_env("SLIM_TLS_INSECURE", "true").lower() == "true",


### PR DESCRIPTION
## Summary
Add SLIM transport support to guide and tourist ADK agents, enabling all agents to communicate via SLIM gateway.

## Changes
- Add SLIM client transport to guide/tourist agents via `a2a_client_factory` parameter
- Update scheduler SLIM local ID to `agntcy/tourist_scheduling/scheduler`
- Add `send_communication_event()` for dashboard communication log tracking
- Update `run.sh` with `--real-agents` option to run actual ADK agents
- Update K8s manifests with SLIM env vars (SLIM_SHARED_SECRET, SLIM_TLS_INSECURE, SCHEDULER_SLIM_TOPIC)
- Update `slim_transport.py` `config_from_env()` to support SLIM_GATEWAY_HOST/PORT
- Update scheduler Dockerfile to pass TRANSPORT_MODE to main.py

## Testing
Tested locally with 5 guides + 6 tourists - all agents communicated via SLIM successfully.

## Usage
```bash
./run.sh --transport slim --real-agents --guides 5 --tourists 6
```