### PR TITLE
fix(k8s): correct UI agent dashboard import and service port

### DIFF
--- a/tourist_scheduling_system/deploy/k8s/deploy.sh
+++ b/tourist_scheduling_system/deploy/k8s/deploy.sh
@@ -134,7 +134,7 @@ deploy_http() {
     # Set transport mode to HTTP
     export TRANSPORT_MODE=http
     export SCHEDULER_URL="http://scheduler-agent:10000"
-    export UI_DASHBOARD_URL="http://ui-dashboard-agent:10021"
+    export UI_DASHBOARD_URL="http://ui-dashboard-agent:80/api/update"
 
     # Verify namespace exists
     if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then


### PR DESCRIPTION
## Description
This PR fixes two critical issues preventing the UI Dashboard Agent from running correctly in Kubernetes:

1.  **Container Crash Fix**: The `containers/ui/main.py` entry point was attempting to import `agents.dashboard`, which does not exist (it is located at `core.dashboard`). This caused an `ImportError` that was silently caught, resulting in the application starting without the dashboard and missing the `/health` endpoint, leading to liveness probe failures.
    *   **Fix**: Corrected the import to `core.dashboard`.
    *   **Fix**: Updated the code to use the global `get_dashboard_state()` from the agent to ensure the dashboard displays live data.
    *   **Fix**: Hooked up the agent's broadcaster to push updates to the dashboard.

2.  **Network Configuration Fix**: The `deploy/k8s/deploy.sh` script was configuring the `UI_DASHBOARD_URL` to point to port `10021` (the container port). However, the Kubernetes Service exposes port `80`.
    *   **Fix**: Updated `UI_DASHBOARD_URL` to point to `http://ui-dashboard-agent:80/api/update`.

## Testing
- Verified locally that the imports are correct.
- Verified the deployment script configuration matches the Service definition.

## Checklist
- [x] Fixes container crash
- [x] Fixes network connectivity in K8s
