### PR TITLE
ci: add frontend container build to workflow

### DIFF
--- a/.github/workflows/build-tss-images.yml
+++ b/.github/workflows/build-tss-images.yml
@@ -78,6 +78,9 @@ jobs:
           - name: ui-agent
             dockerfile: containers/ui/Dockerfile
             context: tourist_scheduling_system
+          - name: frontend
+            dockerfile: containers/frontend/Dockerfile
+            context: tourist_scheduling_system
           - name: guide-agent
             dockerfile: containers/guide/Dockerfile
             context: tourist_scheduling_system


### PR DESCRIPTION
Adds the frontend container build to the `build-tss-images.yml` workflow. This ensures the Flutter web app image is built and pushed to the container registry alongside the backend agents.