### PR TITLE
fix(frontend): use dynamic baseUrl for initial state fetch

### DIFF
--- a/tourist_scheduling_system/frontend/lib/main.dart
+++ b/tourist_scheduling_system/frontend/lib/main.dart
@@ -203,7 +203,8 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _fetchState() async {
     try {
-      final response = await http.get(Uri.parse('http://127.0.0.1:10021/api/state'));
+            final baseUrl = kReleaseMode ? Uri.base.origin : 'http://127.0.0.1:10021';
+      final response = await http.get(Uri.parse('$baseUrl/api/state'));
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
         _handleDashboardUpdate({'type': 'initial_state', 'data': data});


### PR DESCRIPTION
Fixes an issue where the frontend dashboard was attempting to fetch initial state from 127.0.0.1:10021, causing the UI to appear empty when deployed in Kubernetes. Updates the _fetchState() method to use the dynamic baseUrl derived from Uri.base.origin in release mode.