### PR TITLE
docs: add documentation for observability_app and slim-multicluster projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Collection of experimental and reference agent applications built on the A2A pro
 |---------|-------------|----------|
 | [`tourist_scheduling_system/`](tourist_scheduling_system/README.md) | Multi-agent tourist scheduling with scheduler, UI dashboard, and autonomous guide/tourist agents | A2A SDK, Google ADK, SLIM, FastAPI, WebSockets, OpenTelemetry |
 | [`network_of_assistants/`](network_of_assistants/README.md) | Network-of-assistants stack (moderator, math, file, web, user proxy) | FastAPI, Docker, A2A SDK |
+| [`observability_app/`](observability_app/README.md) | AI-powered root cause analysis of application performance issues using SLIM for telemetry distribution and an agent for diagnostics | SLIM, OpenTelemetry |
+| [`slim-multicluster/`](slim-multicluster/README.md) | Multicluster customer-remediation scenario with a cloud-hosted troubleshooting agent diagnosing Kubernetes issues across cluster boundaries | SLIM, A2A SDK, Google ADK, MCP, SPIRE, Agent skills |
 
 See each project's README for installation, configuration, and usage instructions.
 


### PR DESCRIPTION
# Description

This PR adds README documentation links and project descriptions to the main monorepo README for two additional agent applications:

### Changes
- **observability_app**: AI-powered root cause analysis demo using SLIM for telemetry distribution and an agent for real-time performance diagnostics
- **slim-multicluster**: Multicluster customer-remediation scenario demonstrating cross-cluster AI agent collaboration for Kubernetes troubleshooting

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
