### PR TITLE
feat: add slim cross transport reference application

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Collection of experimental and reference agent applications built on the A2A pro
 | [`network_of_assistants/`](network_of_assistants/README.md) | Network-of-assistants stack (moderator, math, file, web, user proxy) | FastAPI, Docker, A2A SDK |
 | [`observability_app/`](observability_app/README.md) | AI-powered root cause analysis of application performance issues using SLIM for telemetry distribution and an agent for diagnostics | SLIM, OpenTelemetry |
 | [`slim-multicluster/`](slim-multicluster/README.md) | Multicluster customer-remediation scenario with a cloud-hosted troubleshooting agent diagnosing Kubernetes issues across cluster boundaries | SLIM, A2A SDK, Google ADK, MCP, SPIRE, Agent skills |
+| [`slim-cross-transport/`](slim-cross-transport/README.md) | Browser + native cross-transport demo: WebSocket and gRPC participants on one SLIM node using `@agntcy/slim-bindings-react-native` WASM bindings (build bindings from source — see project README) | SLIM, TypeScript, Vite, WebAssembly |
 
 See each project's README for installation, configuration, and usage instructions.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Collection of experimental and reference agent applications built on the A2A pro
 | [`network_of_assistants/`](network_of_assistants/README.md) | Network-of-assistants stack (moderator, math, file, web, user proxy) | FastAPI, Docker, A2A SDK |
 | [`observability_app/`](observability_app/README.md) | AI-powered root cause analysis of application performance issues using SLIM for telemetry distribution and an agent for diagnostics | SLIM, OpenTelemetry |
 | [`slim-multicluster/`](slim-multicluster/README.md) | Multicluster customer-remediation scenario with a cloud-hosted troubleshooting agent diagnosing Kubernetes issues across cluster boundaries | SLIM, A2A SDK, Google ADK, MCP, SPIRE, Agent skills |
-| [`slim-cross-transport/`](slim-cross-transport/README.md) | Browser + native cross-transport demo: WebSocket and gRPC participants on one SLIM node using `@agntcy/slim-bindings-react-native` WASM bindings (build bindings from source — see project README) | SLIM, TypeScript, Vite, WebAssembly |
+| [`slim-cross-transport/`](slim-cross-transport/README.md) | Browser + native cross-transport demo: WebSocket and gRPC participants on one SLIM node using `@agntcy/slim-bindings-react-native` WASM bindings (npm) | SLIM, TypeScript, Vite, WebAssembly |
 
 See each project's README for installation, configuration, and usage instructions.
 

--- a/slim-cross-transport/.gitignore
+++ b/slim-cross-transport/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/slim-cross-transport/README.md
+++ b/slim-cross-transport/README.md
@@ -32,13 +32,9 @@ node config: WebSocket on `:46357` and gRPC on `:46358`.
 └───────────────────────────┘
 ```
 
-Browser bindings are installed from npm — no local `slim-bindings` checkout or WASM build required:
-
-```json
-"@agntcy/slim-bindings-react-native": "2.0.0-alpha.7"
-```
-
-The `/web` entry point and prebuilt `index_bg.wasm` ship inside that package.
+The browser UI depends on
+[`@agntcy/slim-bindings-react-native@2.0.0-alpha.7`](https://www.npmjs.com/package/@agntcy/slim-bindings-react-native/v/2.0.0-alpha.7).
+The `/web` entry point and prebuilt `index_bg.wasm` ship in that package.
 
 ---
 

--- a/slim-cross-transport/README.md
+++ b/slim-cross-transport/README.md
@@ -1,0 +1,369 @@
+# SLIM Cross-Transport Demo
+
+A self-contained demo of SLIM cross-transport messaging in the browser. It runs **three browser
+participants** (WASM bindings over WebSocket via `@agntcy/slim-bindings-react-native`), **two native WebSocket clients**,
+and **two native gRPC clients** against a **single dual-transport SLIM node** -
+all on one set of channels. The browser is the moderator and can create multiple
+sessions at once (multicast or unicast, MLS or plaintext), so a single
+participant can be in two sessions simultaneously.
+
+This README is the source of truth for running the demo. It uses this demo's own
+node config: WebSocket on `:46357` and gRPC on `:46358`.
+
+```
+┌───────────────────────────┐
+│ Browser participants      │
+│ • browser-a (moderator)   │──── WebSocket ────┐
+│ • browser-b               │                   │
+│ • browser-c               │                   │
+└───────────────────────────┘                   │
+                                                ▼
+┌───────────────────────────┐       ┌───────────────────────────┐
+│ Native WebSocket clients  │       │ SLIM node                 │
+│ • native-ws-1             │──────>│ • WebSocket :46357        │
+│ • native-ws-2             │  WS   │ • gRPC :46358             │
+└───────────────────────────┘       │ • Shared routing fabric   │
+                                    └───────────────────────────┘
+                                                ▲
+┌───────────────────────────┐                   │
+│ Native gRPC clients       │                   │
+│ • native-grpc-1           │────── gRPC ───────┘
+│ • native-grpc-2           │
+└───────────────────────────┘
+```
+
+> **Note:** The browser WASM bindings are **not published to npm yet**. This demo
+> installs `@agntcy/slim-bindings-react-native` from a local `slim-bindings`
+> checkout and expects you to **build the bindings manually** before running the
+> UI. Follow the steps below in order.
+
+---
+
+## Prerequisites
+
+Install these tools once on your machine:
+
+| Tool | Version / notes |
+| --- | --- |
+| [Node.js](https://nodejs.org/) | 18 or later |
+| [Rust](https://rustup.rs/) | 1.70 or later |
+| Rust `wasm32` target | `rustup target add wasm32-unknown-unknown` |
+| [Task](https://taskfile.dev/) | task runner used by this demo and slim-bindings |
+| `wasm-bindgen-cli` | exactly **0.2.106** — installed automatically by the bindings build, or manually: `cargo install wasm-bindgen-cli --version 0.2.106` |
+
+---
+
+## Step 1 — Clone the repositories
+
+Create a workspace folder and clone all three repos as **siblings**:
+
+```bash
+mkdir -p ~/slim-workspace && cd ~/slim-workspace
+
+git clone https://github.com/agntcy/agentic-apps.git
+git clone https://github.com/agntcy/slim.git
+git clone https://github.com/agntcy/slim-bindings.git
+```
+
+Your directory layout must look like this (paths are relative to `~/slim-workspace`):
+
+```
+slim-workspace/
+├── agentic-apps/
+│   └── slim-cross-transport/     ← this demo
+├── slim/                         ← SLIM node + native client examples
+└── slim-bindings/
+    └── react-native/             ← @agntcy/slim-bindings-react-native (built from source)
+```
+
+The demo's `package.json` links the bindings with:
+
+```json
+"@agntcy/slim-bindings-react-native": "file:../../slim-bindings/react-native"
+```
+
+That path resolves from `agentic-apps/slim-cross-transport/` up to `slim-workspace/`, then into `slim-bindings/react-native`. If your clones are not siblings, update that path or recreate the layout above.
+
+Use a **wasm-clean branch** of `slim` (typically `main`). The WASM build compiles SLIM crates for `wasm32`; branches that pull full `tonic` transport for all targets will fail (see [Troubleshooting](#troubleshooting)).
+
+---
+
+## Step 2 — Build the React Native bindings (browser WASM)
+
+The browser UI imports from `@agntcy/slim-bindings-react-native/web`. That entry point and the `index_bg.wasm` binary are **generated locally** — they are not shipped in the current npm release.
+
+From the bindings package:
+
+```bash
+cd ~/slim-workspace/slim-bindings/react-native
+
+# Install JS tooling (uniffi-bindgen-react-native, TypeScript, etc.)
+npm install
+
+# Generate browser TypeScript + WebAssembly (one-time, or after bindings changes)
+npm run build:web
+```
+
+Under the hood, `npm run build:web` runs `task generate:web`, which:
+
+1. Installs `wasm-bindgen-cli` 0.2.106 if missing
+2. Runs `ubrn build web` to compile the Rust WASM crate and emit TypeScript
+3. Writes output to `generated/web/` (including `generated/web/wasm-bindgen/index_bg.wasm`)
+
+**Verify the build succeeded:**
+
+```bash
+test -f generated/web/wasm-bindgen/index_bg.wasm && echo "WASM OK"
+test -f web.ts && echo "web entry OK"
+```
+
+If either check fails, see [Troubleshooting](#troubleshooting) before continuing.
+
+> **iOS / Android only:** Native React Native bindings use `task generate` (not needed for this browser demo). This demo only requires the **web** build above.
+
+---
+
+## Step 3 — Install the demo app
+
+With the bindings built, install the demo's npm dependencies (this creates the symlink into `slim-bindings/react-native`):
+
+```bash
+cd ~/slim-workspace/agentic-apps/slim-cross-transport
+
+npm install
+```
+
+**Optional — confirm the link:**
+
+```bash
+ls node_modules/@agntcy/slim-bindings-react-native/generated/web/wasm-bindgen/index_bg.wasm
+```
+
+You should see the WASM file from your Step 2 build.
+
+---
+
+## Step 4 — Run the demo
+
+Each long-running process needs its **own terminal**. All commands below assume you are in `agentic-apps/slim-cross-transport` unless noted.
+
+### Terminal 1 — SLIM node (dual transport)
+
+```bash
+cd ~/slim-workspace/agentic-apps/slim-cross-transport
+task node
+```
+
+Starts the SLIM data-plane node with:
+
+- WebSocket on `ws://0.0.0.0:46357` (browser + native WebSocket clients)
+- gRPC on `0.0.0.0:46358` (native gRPC clients)
+
+Leave this running.
+
+### Terminals 2–5 — Native participants
+
+Start all four native clients. Each waits for a browser invite:
+
+```bash
+cd ~/slim-workspace/agentic-apps/slim-cross-transport
+
+task native:grpc-1   # terminal 2
+task native:grpc-2   # terminal 3
+task native:ws-1     # terminal 4
+task native:ws-2     # terminal 5
+```
+
+Wait until **each** terminal prints:
+
+```
+connection established (conn …)
+CLIENT: Entering message receive loop
+```
+
+before creating a session in the browser.
+
+### Terminal 6 — Browser UI
+
+```bash
+cd ~/slim-workspace/agentic-apps/slim-cross-transport
+task ui
+```
+
+Serves the Vite dev server at **http://127.0.0.1:5173**.
+
+---
+
+## Step 5 — Use the browser UI
+
+Open **three tabs** at http://127.0.0.1:5173.
+
+In every tab:
+
+| Field | Value |
+| --- | --- |
+| **WebSocket endpoint** | `ws://127.0.0.1:46357` (prefilled — do not change unless you changed the node port) |
+| **Shared secret** | `test-shared-secret-value-0123456789abcdef` (prefilled — all participants must match) |
+
+Set **Mode** and **Local name** per tab:
+
+| Tab | Mode | Local name |
+| --- | --- | --- |
+| 1 | Moderator | `org/default/browser-a` |
+| 2 | Participant | `org/default/browser-b` |
+| 3 | Participant | `org/default/browser-c` |
+
+Click **Connect** in all three tabs. Participants auto-accept incoming sessions; the moderator creates them.
+
+To run a cross-transport multicast session from the moderator tab:
+
+1. Delivery: **Multicast (group)**
+2. Channel: `org/default/room-1`
+3. Invitees (one per line): `org/default/browser-b`, `org/default/native-ws-1`, `org/default/native-grpc-1`
+4. Click **Create session**, then send a message from the session card
+
+---
+
+## Quick reference — Task commands
+
+Run from `agentic-apps/slim-cross-transport`:
+
+| Task | Purpose |
+| --- | --- |
+| `task wasm` | Rebuild browser WASM bindings (runs `npm run build:web` in `slim-bindings/react-native`) |
+| `task node` | Start dual-transport SLIM node |
+| `task native:ws-1` / `native:ws-2` | Native WebSocket participants |
+| `task native:grpc-1` / `native:grpc-2` | Native gRPC participants |
+| `task ui` | Vite dev server for the browser UI |
+| `task native:chat-ws` | Interactive native WebSocket chat (optional) |
+| `task native:chat-grpc` | Interactive native gRPC chat (optional) |
+
+---
+
+## Demo files
+
+| Path | Purpose |
+| --- | --- |
+| `configs/server-config.yaml` | Dual-transport node (`:46357` ws + `:46358` gRPC) |
+| `configs/native-ws-client.yaml` | Native WebSocket client transport |
+| `configs/native-grpc-client.yaml` | Native gRPC client transport |
+| `Taskfile.yaml` | Orchestration tasks for node, clients, wasm, UI |
+| `src/main.ts` | Connect / create+invite / listen flow |
+| `src/session-card.ts` | Per-session UI (send, roster, close) |
+| `index.html` | Multi-session browser shell |
+
+---
+
+## Recording script
+
+1. **Intro.** All seven participants are up: three browser tabs, two native
+   gRPC clients, two native WebSocket clients, one SLIM node.
+2. **Multicast + MLS across transports.** In the moderator tab (`browser-a`),
+   keep **Multicast**, leave **Enable MLS** on, channel `org/default/room-1`,
+   invitees `browser-b`, `native-ws-1`, `native-grpc-1`. Click **Create
+   session**. A card appears; send a message. It fans out to the browser tab and
+   both native transports (watch the native terminals). The node only sees
+   ciphertext.
+3. **A second session, no MLS.** Still in the moderator tab, without closing
+   room-1: switch to channel `org/default/room-2`, turn **Enable MLS** off,
+   invitees `browser-c`, `native-ws-2`, `native-ws-1`. Click **Create session**.
+   The moderator now shows **two active session cards at once**, and
+   `native-ws-1` is a member of both room-1 and room-2 - the "one participant,
+   two sessions" moment.
+4. **One participant, two sessions (browser).** In the `browser-b` tab (already
+   in room-1 as an invitee), switch delivery to Multicast, channel
+   `org/default/room-2b`, invitees `browser-c`, and click **Create session**.
+   `browser-b` now has two session cards too - a participant that is also
+   moderating its own second session.
+5. **Unicast, optional.** In `browser-b` choose **Unicast**, remote
+   `org/default/browser-c`, enable MLS, and create a point-to-point session with
+   `browser-c`.
+6. **Wrap up.** Send messages in different cards to show they are independent,
+   then **Close session** on each card and **Disconnect**.
+
+---
+
+## UI reference
+
+| Control | Purpose |
+| --- | --- |
+| Mode | `Moderator` creates sessions; `Participant` auto-accepts incoming sessions on connect |
+| WebSocket endpoint | `ws://` (or `wss://`) address of the node's WebSocket listener |
+| Local name | Any three-component SLIM application name you choose (`org/namespace/name`) |
+| Shared secret | Common end-to-end identity secret (>= 32 chars) |
+| Auth token | Only for auth-enabled servers (WebSocket query token) |
+| Auto-accept incoming sessions | Runs a loop that accepts every invitation as a new card |
+| Delivery / Enable MLS | Session type and per-session end-to-end encryption |
+| Channel / Participants | Multicast destination and invitees |
+| Remote participant | Unicast destination |
+| Create session | Installs upstream routes, creates the session, invites participants |
+| Invite (session card) | On a group session you moderate, add a new participant mid-session (routes then invites them) |
+| Session card | Independent send box, message log, participant roster, and Close |
+
+---
+
+## Notes and limitations
+
+- The browser is the **moderator**. The native [`client`](../../slim/crates/examples/src/client/main.rs)
+  example is a passive participant (accepts sessions, sends its one `--message`);
+  it cannot create/invite. Native-moderated flows would need a new native
+  example.
+- Transport is selected by endpoint scheme: `ws://`/`wss://` = WebSocket, bare
+  `host:port` / `http://` = gRPC.
+- Invitations target three-component **application** names (e.g.
+  `org/default/native-ws-1`), not instance names like `org/default/native-ws/1`.
+
+---
+
+## Troubleshooting
+
+### Bindings build
+
+- **`task wasm` / `npm run build:web` fails compiling `mio` for `wasm32`**
+  Your `slim` / `slim-bindings` checkout may not be wasm-clean. Use `main` (or another branch known to build for `wasm32`) and rebuild.
+- **`wasm-bindgen` version mismatch**
+  Install exactly 0.2.106: `cargo install wasm-bindgen-cli --version 0.2.106`
+- **`ubrn: command not found`**
+  Run `npm install` inside `slim-bindings/react-native` first; the build uses `npx ubrn`.
+
+### Demo runtime
+
+- **`403 Forbidden` for `index_bg.wasm`**
+  Run the UI via `task ui` (not by opening `index.html` directly). Vite must serve the WASM from the linked bindings package. Re-run Step 2 if the file is missing.
+- **`Cannot find module '@agntcy/slim-bindings-react-native/web'`**
+  Complete Step 2 (`npm run build:web`) and Step 3 (`npm install` in this folder).
+- **Invite times out / participant never joins** — check in order:
+  1. **Endpoint** — every browser tab uses `ws://127.0.0.1:46357`
+  2. **Names** — invited names match each participant's Local name exactly (e.g. `org/default/native-ws-1`)
+  3. **Secret** — same shared secret everywhere
+  4. **Native clients** — all four running and showing `connection established` before Create session
+  5. **MLS** — if invites time out with MLS on, retry once with **Enable MLS** off
+- **Native clients do not join** — confirm the node listens on `:46357` (ws) and `:46358` (grpc)
+- **HTTPS page cannot connect** — use a `wss://` endpoint on a TLS-terminated node
+
+---
+
+## End-to-end checklist
+
+Use this if something is not working:
+
+```bash
+# 1. Layout
+ls ~/slim-workspace/agentic-apps/slim-cross-transport
+ls ~/slim-workspace/slim
+ls ~/slim-workspace/slim-bindings/react-native
+
+# 2. WASM built
+test -f ~/slim-workspace/slim-bindings/react-native/generated/web/wasm-bindgen/index_bg.wasm
+
+# 3. Demo deps linked
+cd ~/slim-workspace/agentic-apps/slim-cross-transport && npm install
+test -f node_modules/@agntcy/slim-bindings-react-native/generated/web/wasm-bindgen/index_bg.wasm
+
+# 4. Run (separate terminals)
+task node
+task native:grpc-1 && task native:grpc-2 && task native:ws-1 && task native:ws-2
+task ui
+```
+
+Then open http://127.0.0.1:5173 and connect three browser tabs as described in Step 5.

--- a/slim-cross-transport/README.md
+++ b/slim-cross-transport/README.md
@@ -32,125 +32,72 @@ node config: WebSocket on `:46357` and gRPC on `:46358`.
 └───────────────────────────┘
 ```
 
-> **Note:** The browser WASM bindings are **not published to npm yet**. This demo
-> installs `@agntcy/slim-bindings-react-native` from a local `slim-bindings`
-> checkout and expects you to **build the bindings manually** before running the
-> UI. Follow the steps below in order.
+Browser bindings are installed from npm — no local `slim-bindings` checkout or WASM build required:
+
+```json
+"@agntcy/slim-bindings-react-native": "2.0.0-alpha.7"
+```
+
+The `/web` entry point and prebuilt `index_bg.wasm` ship inside that package.
 
 ---
 
 ## Prerequisites
 
-Install these tools once on your machine:
-
 | Tool | Version / notes |
 | --- | --- |
 | [Node.js](https://nodejs.org/) | 18 or later |
-| [Rust](https://rustup.rs/) | 1.70 or later |
-| Rust `wasm32` target | `rustup target add wasm32-unknown-unknown` |
-| [Task](https://taskfile.dev/) | task runner used by this demo and slim-bindings |
-| `wasm-bindgen-cli` | exactly **0.2.106** — installed automatically by the bindings build, or manually: `cargo install wasm-bindgen-cli --version 0.2.106` |
+| [Rust](https://rustup.rs/) | 1.70 or later (for the SLIM node and native clients) |
+| [Task](https://taskfile.dev/) | task runner for orchestrating demo processes |
 
 ---
 
 ## Step 1 — Clone the repositories
 
-Create a workspace folder and clone all three repos as **siblings**:
+Create a workspace folder and clone **agentic-apps** and **slim** as siblings:
 
 ```bash
 mkdir -p ~/slim-workspace && cd ~/slim-workspace
 
 git clone https://github.com/agntcy/agentic-apps.git
 git clone https://github.com/agntcy/slim.git
-git clone https://github.com/agntcy/slim-bindings.git
 ```
 
-Your directory layout must look like this (paths are relative to `~/slim-workspace`):
+Layout:
 
 ```
 slim-workspace/
 ├── agentic-apps/
 │   └── slim-cross-transport/     ← this demo
-├── slim/                         ← SLIM node + native client examples
-└── slim-bindings/
-    └── react-native/             ← @agntcy/slim-bindings-react-native (built from source)
+└── slim/                         ← SLIM node + native client examples
 ```
-
-The demo's `package.json` links the bindings with:
-
-```json
-"@agntcy/slim-bindings-react-native": "file:../../slim-bindings/react-native"
-```
-
-That path resolves from `agentic-apps/slim-cross-transport/` up to `slim-workspace/`, then into `slim-bindings/react-native`. If your clones are not siblings, update that path or recreate the layout above.
-
-Use a **wasm-clean branch** of `slim` (typically `main`). The WASM build compiles SLIM crates for `wasm32`; branches that pull full `tonic` transport for all targets will fail (see [Troubleshooting](#troubleshooting)).
 
 ---
 
-## Step 2 — Build the React Native bindings (browser WASM)
-
-The browser UI imports from `@agntcy/slim-bindings-react-native/web`. That entry point and the `index_bg.wasm` binary are **generated locally** — they are not shipped in the current npm release.
-
-From the bindings package:
-
-```bash
-cd ~/slim-workspace/slim-bindings/react-native
-
-# Install JS tooling (uniffi-bindgen-react-native, TypeScript, etc.)
-npm install
-
-# Generate browser TypeScript + WebAssembly (one-time, or after bindings changes)
-npm run build:web
-```
-
-Under the hood, `npm run build:web` runs `task generate:web`, which:
-
-1. Installs `wasm-bindgen-cli` 0.2.106 if missing
-2. Runs `ubrn build web` to compile the Rust WASM crate and emit TypeScript
-3. Writes output to `generated/web/` (including `generated/web/wasm-bindgen/index_bg.wasm`)
-
-**Verify the build succeeded:**
-
-```bash
-test -f generated/web/wasm-bindgen/index_bg.wasm && echo "WASM OK"
-test -f web.ts && echo "web entry OK"
-```
-
-If either check fails, see [Troubleshooting](#troubleshooting) before continuing.
-
-> **iOS / Android only:** Native React Native bindings use `task generate` (not needed for this browser demo). This demo only requires the **web** build above.
-
----
-
-## Step 3 — Install the demo app
-
-With the bindings built, install the demo's npm dependencies (this creates the symlink into `slim-bindings/react-native`):
+## Step 2 — Install the demo app
 
 ```bash
 cd ~/slim-workspace/agentic-apps/slim-cross-transport
-
 npm install
 ```
 
-**Optional — confirm the link:**
+This pulls [`@agntcy/slim-bindings-react-native@2.0.0-alpha.7`](https://www.npmjs.com/package/@agntcy/slim-bindings-react-native/v/2.0.0-alpha.7) from npm, including the browser WASM binary.
+
+**Optional — confirm WASM is present:**
 
 ```bash
-ls node_modules/@agntcy/slim-bindings-react-native/generated/web/wasm-bindgen/index_bg.wasm
+test -f node_modules/@agntcy/slim-bindings-react-native/generated/web/wasm-bindgen/index_bg.wasm && echo "WASM OK"
 ```
-
-You should see the WASM file from your Step 2 build.
 
 ---
 
-## Step 4 — Run the demo
+## Step 3 — Run the demo
 
-Each long-running process needs its **own terminal**. All commands below assume you are in `agentic-apps/slim-cross-transport` unless noted.
+Each long-running process needs its **own terminal**. All commands below run from `agentic-apps/slim-cross-transport`.
 
 ### Terminal 1 — SLIM node (dual transport)
 
 ```bash
-cd ~/slim-workspace/agentic-apps/slim-cross-transport
 task node
 ```
 
@@ -159,15 +106,9 @@ Starts the SLIM data-plane node with:
 - WebSocket on `ws://0.0.0.0:46357` (browser + native WebSocket clients)
 - gRPC on `0.0.0.0:46358` (native gRPC clients)
 
-Leave this running.
-
 ### Terminals 2–5 — Native participants
 
-Start all four native clients. Each waits for a browser invite:
-
 ```bash
-cd ~/slim-workspace/agentic-apps/slim-cross-transport
-
 task native:grpc-1   # terminal 2
 task native:grpc-2   # terminal 3
 task native:ws-1     # terminal 4
@@ -186,7 +127,6 @@ before creating a session in the browser.
 ### Terminal 6 — Browser UI
 
 ```bash
-cd ~/slim-workspace/agentic-apps/slim-cross-transport
 task ui
 ```
 
@@ -194,7 +134,7 @@ Serves the Vite dev server at **http://127.0.0.1:5173**.
 
 ---
 
-## Step 5 — Use the browser UI
+## Step 4 — Use the browser UI
 
 Open **three tabs** at http://127.0.0.1:5173.
 
@@ -202,8 +142,8 @@ In every tab:
 
 | Field | Value |
 | --- | --- |
-| **WebSocket endpoint** | `ws://127.0.0.1:46357` (prefilled — do not change unless you changed the node port) |
-| **Shared secret** | `test-shared-secret-value-0123456789abcdef` (prefilled — all participants must match) |
+| **WebSocket endpoint** | `ws://127.0.0.1:46357` (prefilled) |
+| **Shared secret** | `test-shared-secret-value-0123456789abcdef` (prefilled) |
 
 Set **Mode** and **Local name** per tab:
 
@@ -226,11 +166,8 @@ To run a cross-transport multicast session from the moderator tab:
 
 ## Quick reference — Task commands
 
-Run from `agentic-apps/slim-cross-transport`:
-
 | Task | Purpose |
 | --- | --- |
-| `task wasm` | Rebuild browser WASM bindings (runs `npm run build:web` in `slim-bindings/react-native`) |
 | `task node` | Start dual-transport SLIM node |
 | `task native:ws-1` / `native:ws-2` | Native WebSocket participants |
 | `task native:grpc-1` / `native:grpc-2` | Native gRPC participants |
@@ -247,7 +184,7 @@ Run from `agentic-apps/slim-cross-transport`:
 | `configs/server-config.yaml` | Dual-transport node (`:46357` ws + `:46358` gRPC) |
 | `configs/native-ws-client.yaml` | Native WebSocket client transport |
 | `configs/native-grpc-client.yaml` | Native gRPC client transport |
-| `Taskfile.yaml` | Orchestration tasks for node, clients, wasm, UI |
+| `Taskfile.yaml` | Orchestration tasks for node, clients, UI |
 | `src/main.ts` | Connect / create+invite / listen flow |
 | `src/session-card.ts` | Per-session UI (send, roster, close) |
 | `index.html` | Multi-session browser shell |
@@ -317,21 +254,8 @@ Run from `agentic-apps/slim-cross-transport`:
 
 ## Troubleshooting
 
-### Bindings build
-
-- **`task wasm` / `npm run build:web` fails compiling `mio` for `wasm32`**
-  Your `slim` / `slim-bindings` checkout may not be wasm-clean. Use `main` (or another branch known to build for `wasm32`) and rebuild.
-- **`wasm-bindgen` version mismatch**
-  Install exactly 0.2.106: `cargo install wasm-bindgen-cli --version 0.2.106`
-- **`ubrn: command not found`**
-  Run `npm install` inside `slim-bindings/react-native` first; the build uses `npx ubrn`.
-
-### Demo runtime
-
-- **`403 Forbidden` for `index_bg.wasm`**
-  Run the UI via `task ui` (not by opening `index.html` directly). Vite must serve the WASM from the linked bindings package. Re-run Step 2 if the file is missing.
-- **`Cannot find module '@agntcy/slim-bindings-react-native/web'`**
-  Complete Step 2 (`npm run build:web`) and Step 3 (`npm install` in this folder).
+- **`403 Forbidden` for `index_bg.wasm`** — run via `task ui` at http://127.0.0.1:5173/, not by opening `index.html` directly. Re-run `npm install` if the WASM file is missing from `node_modules`.
+- **`Cannot find module '@agntcy/slim-bindings-react-native/web'`** — run `npm install` in this folder.
 - **Invite times out / participant never joins** — check in order:
   1. **Endpoint** — every browser tab uses `ws://127.0.0.1:46357`
   2. **Names** — invited names match each participant's Local name exactly (e.g. `org/default/native-ws-1`)
@@ -345,25 +269,19 @@ Run from `agentic-apps/slim-cross-transport`:
 
 ## End-to-end checklist
 
-Use this if something is not working:
-
 ```bash
 # 1. Layout
 ls ~/slim-workspace/agentic-apps/slim-cross-transport
 ls ~/slim-workspace/slim
-ls ~/slim-workspace/slim-bindings/react-native
 
-# 2. WASM built
-test -f ~/slim-workspace/slim-bindings/react-native/generated/web/wasm-bindgen/index_bg.wasm
-
-# 3. Demo deps linked
+# 2. Demo deps (includes npm WASM bindings)
 cd ~/slim-workspace/agentic-apps/slim-cross-transport && npm install
 test -f node_modules/@agntcy/slim-bindings-react-native/generated/web/wasm-bindgen/index_bg.wasm
 
-# 4. Run (separate terminals)
+# 3. Run (separate terminals)
 task node
 task native:grpc-1 && task native:grpc-2 && task native:ws-1 && task native:ws-2
 task ui
 ```
 
-Then open http://127.0.0.1:5173 and connect three browser tabs as described in Step 5.
+Then open http://127.0.0.1:5173 and connect three browser tabs as described in Step 4.

--- a/slim-cross-transport/Taskfile.yaml
+++ b/slim-cross-transport/Taskfile.yaml
@@ -9,29 +9,20 @@ silent: true
 # Orchestrates the slim-cross-transport browser demo. Each long-running task is
 # meant to run in its own terminal (Task does not multiplex daemons cleanly).
 #
-# Layout assumptions (sibling checkouts next to agentic-apps):
-#   <root>/slim              - the SLIM core repo (provides `slim` and `client` bins)
-#   <root>/slim-bindings     - browser WASM + React Native bindings package
+# Layout assumptions (sibling checkout next to agentic-apps):
+#   <root>/slim  - the SLIM core repo (provides `slim` and `client` bins)
 #
-# {{.TASKFILE_DIR}} is this demo folder; {{.SLIM_DIR}} is the sibling slim repo
-# and {{.BINDINGS_DIR}} is the react-native bindings package root.
+# Browser WASM bindings come from npm:
+#   @agntcy/slim-bindings-react-native@2.0.0-alpha.7
 
 vars:
   SLIM_DIR: "{{.TASKFILE_DIR}}/../../slim"
-  BINDINGS_DIR: "{{.TASKFILE_DIR}}/../../slim-bindings/react-native"
   SECRET: "test-shared-secret-value-0123456789abcdef"
 
 tasks:
   default:
     cmds:
       - task -l
-
-  wasm:
-    desc: "Build the browser WASM bindings (one-time; regenerates generated/web)"
-    dir: "{{.BINDINGS_DIR}}"
-    cmds:
-      - npm install
-      - npm run build:web
 
   node:
     desc: "Run the dual-transport SLIM node (ws :46357 + grpc :46358)"

--- a/slim-cross-transport/Taskfile.yaml
+++ b/slim-cross-transport/Taskfile.yaml
@@ -1,0 +1,111 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+version: "3"
+
+silent: true
+
+# Orchestrates the slim-cross-transport browser demo. Each long-running task is
+# meant to run in its own terminal (Task does not multiplex daemons cleanly).
+#
+# Layout assumptions (sibling checkouts next to agentic-apps):
+#   <root>/slim              - the SLIM core repo (provides `slim` and `client` bins)
+#   <root>/slim-bindings     - browser WASM + React Native bindings package
+#
+# {{.TASKFILE_DIR}} is this demo folder; {{.SLIM_DIR}} is the sibling slim repo
+# and {{.BINDINGS_DIR}} is the react-native bindings package root.
+
+vars:
+  SLIM_DIR: "{{.TASKFILE_DIR}}/../../slim"
+  BINDINGS_DIR: "{{.TASKFILE_DIR}}/../../slim-bindings/react-native"
+  SECRET: "test-shared-secret-value-0123456789abcdef"
+
+tasks:
+  default:
+    cmds:
+      - task -l
+
+  wasm:
+    desc: "Build the browser WASM bindings (one-time; regenerates generated/web)"
+    dir: "{{.BINDINGS_DIR}}"
+    cmds:
+      - npm install
+      - npm run build:web
+
+  node:
+    desc: "Run the dual-transport SLIM node (ws :46357 + grpc :46358)"
+    dir: "{{.SLIM_DIR}}"
+    cmds:
+      - cargo run --bin slim -- --config {{.TASKFILE_DIR}}/configs/server-config.yaml
+
+  native:ws-1:
+    desc: "Native WebSocket participant org/default/native-ws-1"
+    dir: "{{.SLIM_DIR}}"
+    cmds:
+      - >-
+        cargo run -p slim-examples --bin client --
+        --config {{.TASKFILE_DIR}}/configs/native-ws-client.yaml
+        --local-name org/default/native-ws-1
+        --secret {{.SECRET}}
+        --message "hello from native-ws-1 (WebSocket)"
+
+  native:ws-2:
+    desc: "Native WebSocket participant org/default/native-ws-2"
+    dir: "{{.SLIM_DIR}}"
+    cmds:
+      - >-
+        cargo run -p slim-examples --bin client --
+        --config {{.TASKFILE_DIR}}/configs/native-ws-client.yaml
+        --local-name org/default/native-ws-2
+        --secret {{.SECRET}}
+        --message "hello from native-ws-2 (WebSocket)"
+
+  native:grpc-1:
+    desc: "Native gRPC participant org/default/native-grpc-1"
+    dir: "{{.SLIM_DIR}}"
+    cmds:
+      - >-
+        cargo run -p slim-examples --bin client --
+        --config {{.TASKFILE_DIR}}/configs/native-grpc-client.yaml
+        --local-name org/default/native-grpc-1
+        --secret {{.SECRET}}
+        --message "hello from native-grpc-1 (gRPC)"
+
+  native:grpc-2:
+    desc: "Native gRPC participant org/default/native-grpc-2"
+    dir: "{{.SLIM_DIR}}"
+    cmds:
+      - >-
+        cargo run -p slim-examples --bin client --
+        --config {{.TASKFILE_DIR}}/configs/native-grpc-client.yaml
+        --local-name org/default/native-grpc-2
+        --secret {{.SECRET}}
+        --message "hello from native-grpc-2 (gRPC)"
+
+  ui:
+    desc: "Serve the browser demo UI (Vite at 127.0.0.1:5173)"
+    dir: "{{.TASKFILE_DIR}}"
+    cmds:
+      - npm install
+      - npm run dev
+
+  native:chat-ws:
+    desc: "Interactive native WebSocket participant (org/default/native-ws/1)"
+    dir: "{{.SLIM_DIR}}"
+    cmds:
+      - >-
+        cargo run -p slim-examples --bin chat --
+        --config {{.TASKFILE_DIR}}/configs/native-ws-client.yaml
+        --name org/default/native-ws/1
+        --channel org/default/room-1
+
+  native:chat-grpc:
+    desc: "Interactive native gRPC participant (org/default/native-grpc/2)"
+    dir: "{{.SLIM_DIR}}"
+    cmds:
+      - >-
+        cargo run -p slim-examples --bin chat --
+        --config {{.TASKFILE_DIR}}/configs/native-grpc-client.yaml
+        --name org/default/native-grpc/2
+        --channel org/default/room-1

--- a/slim-cross-transport/configs/native-grpc-client.yaml
+++ b/slim-cross-transport/configs/native-grpc-client.yaml
@@ -1,0 +1,24 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+# Native client that connects to the demo node over the gRPC listener.
+# The http:// scheme (or a bare host:port) selects the gRPC transport.
+
+tracing:
+  log_level: info
+  display_thread_names: true
+  display_thread_ids: true
+
+runtime:
+  n_cores: 0
+  thread_name: "slim-data-plane"
+  drain_timeout: 10s
+
+services:
+  slim/0:
+    node_id: native-grpc-client
+    dataplane:
+      clients:
+        - endpoint: "http://127.0.0.1:46358"
+          tls:
+            insecure: true

--- a/slim-cross-transport/configs/native-ws-client.yaml
+++ b/slim-cross-transport/configs/native-ws-client.yaml
@@ -1,0 +1,24 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+# Native client that connects to the demo node over the WebSocket listener.
+# The ws:// scheme selects the WebSocket transport (same as the browser tabs).
+
+tracing:
+  log_level: info
+  display_thread_names: true
+  display_thread_ids: true
+
+runtime:
+  n_cores: 0
+  thread_name: "slim-data-plane"
+  drain_timeout: 10s
+
+services:
+  slim/0:
+    node_id: native-ws-client
+    dataplane:
+      clients:
+        - endpoint: "ws://127.0.0.1:46357"
+          tls:
+            insecure: true

--- a/slim-cross-transport/configs/server-config.yaml
+++ b/slim-cross-transport/configs/server-config.yaml
@@ -1,0 +1,33 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+# Dual-transport SLIM data-plane node for the slim-cross-transport demo.
+# A single node exposes two listeners on the same routing fabric:
+#   - ws://0.0.0.0:46357  -> browser (WASM) clients and native WebSocket clients
+#   - 0.0.0.0:46358       -> native gRPC clients (bare host:port = gRPC transport)
+# The transport is inferred from the endpoint scheme; there is no separate
+# transport field. insecure: true keeps the local demo simple - use wss:// + TLS
+# in production.
+
+tracing:
+  log_level: info
+  display_thread_names: true
+  display_thread_ids: true
+
+runtime:
+  n_cores: 0
+  thread_name: "slim-data-plane"
+  drain_timeout: 10s
+
+services:
+  slim/0:
+    node_id: slim-cross-transport
+    dataplane:
+      servers:
+        - endpoint: "ws://0.0.0.0:46357"
+          tls:
+            insecure: true
+        - endpoint: "0.0.0.0:46358"
+          tls:
+            insecure: true
+      clients: []

--- a/slim-cross-transport/index.html
+++ b/slim-cross-transport/index.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SLIM Cross-Transport — WebSocket + gRPC demo</title>
+  </head>
+  <body>
+    <div id="app">
+      <header class="topbar">
+        <div class="brand">
+          <span class="brand-mark">SLIM</span>
+          <div class="brand-text">
+            <h1>SLIM cross-transport</h1>
+            <p>WebSocket + gRPC · one participant, many sessions, mixed transports</p>
+          </div>
+        </div>
+        <div class="badges">
+          <span id="wasm-status" class="badge badge-wait">WASM loading</span>
+          <span id="conn-status" class="badge badge-idle">Disconnected</span>
+        </div>
+      </header>
+
+      <main class="layout">
+        <div class="col">
+          <section class="panel">
+            <h2><span class="step">1</span> Connect</h2>
+            <div class="field">
+              <label for="mode">Mode</label>
+              <select id="mode">
+                <option value="moderator">Moderator — create &amp; invite</option>
+                <option value="participant">Participant — auto-accept invites</option>
+              </select>
+            </div>
+            <p id="mode-hint" class="hint"></p>
+            <div class="field">
+              <label for="endpoint">WebSocket endpoint</label>
+              <input id="endpoint" type="text" value="ws://127.0.0.1:46357" autocomplete="off" />
+            </div>
+            <div class="field">
+              <label for="local-name">Local name (org/namespace/name)</label>
+              <input id="local-name" type="text" value="org/default/browser-a" autocomplete="off" />
+            </div>
+            <div class="field">
+              <label for="secret">Shared secret</label>
+              <input id="secret" type="text" value="test-shared-secret-value-0123456789abcdef" autocomplete="off" />
+            </div>
+            <div class="field">
+              <label for="token">Auth token (optional)</label>
+              <input id="token" type="text" placeholder="only for auth-enabled servers" autocomplete="off" />
+            </div>
+            <div class="row">
+              <button id="connect" type="button" disabled>Connect</button>
+              <button id="disconnect" type="button" class="ghost" disabled>Disconnect</button>
+            </div>
+            <label class="toggle">
+              <input id="auto-accept" type="checkbox" disabled />
+              <span>Auto-accept incoming sessions</span>
+            </label>
+          </section>
+
+          <section class="panel">
+            <h2><span class="step">2</span> Create a session</h2>
+            <p class="hint">
+              Each session becomes its own card, so one participant can hold
+              several at once (multicast or unicast, MLS or plaintext).
+            </p>
+            <div class="field">
+              <label for="session-type">Delivery</label>
+              <select id="session-type">
+                <option value="group">Multicast (group)</option>
+                <option value="point-to-point">Unicast (point-to-point)</option>
+              </select>
+            </div>
+            <label class="toggle">
+              <input id="mls-enabled" type="checkbox" />
+              <span>Enable MLS (end-to-end encryption)</span>
+            </label>
+            <div class="field" id="channel-field">
+              <label for="channel">Channel</label>
+              <input id="channel" type="text" value="org/default/room-1" autocomplete="off" />
+            </div>
+            <div class="field" id="invitees-field">
+              <label for="invitees">Participants to invite (one per line)</label>
+              <textarea id="invitees" rows="3">org/default/browser-b
+org/default/native-ws-1
+org/default/native-grpc-1</textarea>
+            </div>
+            <div class="field" id="destination-field" hidden>
+              <label for="destination">Remote participant</label>
+              <input id="destination" type="text" value="org/default/browser-b" autocomplete="off" />
+            </div>
+            <button id="create-session" type="button" disabled>Create session</button>
+          </section>
+        </div>
+
+        <div class="col col-wide">
+          <section class="panel">
+            <div class="panel-head">
+              <h2>Active sessions</h2>
+              <span id="session-count" class="pill">0</span>
+            </div>
+            <div id="sessions" class="sessions-grid">
+              <div class="empty-state" id="sessions-empty">
+                No active sessions yet. Connect, then create or accept a session.
+              </div>
+            </div>
+          </section>
+
+          <section class="panel">
+            <div class="panel-head">
+              <h2>Event log</h2>
+              <button id="clear-log" type="button" class="ghost small">Clear</button>
+            </div>
+            <pre id="log" class="log"></pre>
+          </section>
+        </div>
+      </main>
+    </div>
+
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/slim-cross-transport/package-lock.json
+++ b/slim-cross-transport/package-lock.json
@@ -1,0 +1,1084 @@
+{
+  "name": "slim-cross-transport",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "slim-cross-transport",
+      "version": "0.1.0",
+      "dependencies": {
+        "@agntcy/slim-bindings-react-native": "file:../../slim-bindings/react-native"
+      },
+      "devDependencies": {
+        "playwright": "^1.61.1",
+        "typescript": "5.9.3",
+        "vite": "5.4.21"
+      }
+    },
+    "../../slim-bindings/react-native": {
+      "name": "@agntcy/slim-bindings-react-native",
+      "version": "0.7.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ubjs/core": "0.31.0-3",
+        "uniffi-bindgen-react-native": "0.31.0-3"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.0",
+        "@vitest/coverage-v8": "^2.0.0",
+        "prettier": "^3.2.5",
+        "typescript": "^5.3.3",
+        "vitest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.72.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@agntcy/slim-bindings-react-native": {
+      "resolved": "../../slim-bindings/react-native",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    }
+  }
+}

--- a/slim-cross-transport/package-lock.json
+++ b/slim-cross-transport/package-lock.json
@@ -8,7 +8,7 @@
       "name": "slim-cross-transport",
       "version": "0.1.0",
       "dependencies": {
-        "@agntcy/slim-bindings-react-native": "file:../../slim-bindings/react-native"
+        "@agntcy/slim-bindings-react-native": "2.0.0-alpha.7"
       },
       "devDependencies": {
         "playwright": "^1.61.1",
@@ -16,20 +16,14 @@
         "vite": "5.4.21"
       }
     },
-    "../../slim-bindings/react-native": {
-      "name": "@agntcy/slim-bindings-react-native",
-      "version": "0.7.0",
+    "node_modules/@agntcy/slim-bindings-react-native": {
+      "version": "2.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@agntcy/slim-bindings-react-native/-/slim-bindings-react-native-2.0.0-alpha.7.tgz",
+      "integrity": "sha512-oZEB3kJ5rPlbb851cJzgYfRixt86QuXIElalIUMNeooIZhhkLa4Es41NE8Trg6aSTI/L3AoxlqP877V3HTejpA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ubjs/core": "0.31.0-3",
         "uniffi-bindgen-react-native": "0.31.0-3"
-      },
-      "devDependencies": {
-        "@types/node": "^20.10.0",
-        "@vitest/coverage-v8": "^2.0.0",
-        "prettier": "^3.2.5",
-        "typescript": "^5.3.3",
-        "vitest": "^2.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -42,10 +36,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@agntcy/slim-bindings-react-native": {
-      "resolved": "../../slim-bindings/react-native",
-      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -438,10 +428,27 @@
         "node": ">=12"
       }
     },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
-      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
       "cpu": [
         "arm"
       ],
@@ -453,9 +460,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
-      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
       "cpu": [
         "arm64"
       ],
@@ -467,9 +474,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
-      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
       "cpu": [
         "arm64"
       ],
@@ -481,9 +488,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
-      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
       "cpu": [
         "x64"
       ],
@@ -495,9 +502,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
-      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
       "cpu": [
         "arm64"
       ],
@@ -509,9 +516,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
-      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
       "cpu": [
         "x64"
       ],
@@ -523,9 +530,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
-      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
       "cpu": [
         "arm"
       ],
@@ -537,9 +544,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
-      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
       "cpu": [
         "arm"
       ],
@@ -551,9 +558,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
-      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
       "cpu": [
         "arm64"
       ],
@@ -565,9 +572,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
-      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
       "cpu": [
         "arm64"
       ],
@@ -579,9 +586,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
-      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
       "cpu": [
         "loong64"
       ],
@@ -593,9 +600,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
-      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
       "cpu": [
         "loong64"
       ],
@@ -607,9 +614,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
-      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
       "cpu": [
         "ppc64"
       ],
@@ -621,9 +628,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
-      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
       "cpu": [
         "ppc64"
       ],
@@ -635,9 +642,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
-      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
       "cpu": [
         "riscv64"
       ],
@@ -649,9 +656,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
-      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
       "cpu": [
         "riscv64"
       ],
@@ -663,9 +670,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
-      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
       "cpu": [
         "s390x"
       ],
@@ -677,9 +684,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
-      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
       "cpu": [
         "x64"
       ],
@@ -691,9 +698,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
-      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
       "cpu": [
         "x64"
       ],
@@ -705,9 +712,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
-      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
       "cpu": [
         "x64"
       ],
@@ -719,9 +726,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
-      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
       "cpu": [
         "arm64"
       ],
@@ -733,9 +740,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
-      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
       "cpu": [
         "arm64"
       ],
@@ -747,9 +754,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
-      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
       "cpu": [
         "ia32"
       ],
@@ -761,9 +768,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
-      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
       "cpu": [
         "x64"
       ],
@@ -775,9 +782,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
-      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
       "cpu": [
         "x64"
       ],
@@ -794,6 +801,12 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ubjs/core": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/core/-/core-0.31.0-3.tgz",
+      "integrity": "sha512-39XrJgUZ2VVb561sSnkXPhczNoeBsNiSRArecsV0JE7CJq69ajFkcn9/tBAUS2NpgHkLIDU+z6Ks2+1wXnboxg==",
+      "license": "MPL-2.0"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -850,9 +863,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -937,9 +950,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
-      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -953,31 +966,32 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.62.3",
-        "@rollup/rollup-android-arm64": "4.62.3",
-        "@rollup/rollup-darwin-arm64": "4.62.3",
-        "@rollup/rollup-darwin-x64": "4.62.3",
-        "@rollup/rollup-freebsd-arm64": "4.62.3",
-        "@rollup/rollup-freebsd-x64": "4.62.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
-        "@rollup/rollup-linux-arm64-musl": "4.62.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
-        "@rollup/rollup-linux-loong64-musl": "4.62.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
-        "@rollup/rollup-linux-x64-gnu": "4.62.3",
-        "@rollup/rollup-linux-x64-musl": "4.62.3",
-        "@rollup/rollup-openbsd-x64": "4.62.3",
-        "@rollup/rollup-openharmony-arm64": "4.62.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
-        "@rollup/rollup-win32-x64-gnu": "4.62.3",
-        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -1003,6 +1017,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uniffi-bindgen-react-native": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/uniffi-bindgen-react-native/-/uniffi-bindgen-react-native-0.31.0-3.tgz",
+      "integrity": "sha512-br7giBJRr/j00rdMXhOZGMGuDWMAVUcxC9O3lco0KRqzEAxUz00+gegPW5tKamvKbrnj7NB682XUCYrcagtxFA==",
+      "license": "MPL-2.0",
+      "bin": {
+        "ubrn": "bin/cli.cjs",
+        "uniffi-bindgen-react-native": "bin/cli.cjs"
       }
     },
     "node_modules/vite": {

--- a/slim-cross-transport/package.json
+++ b/slim-cross-transport/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "slim-cross-transport",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview --host 127.0.0.1"
+  },
+  "dependencies": {
+    "@agntcy/slim-bindings-react-native": "file:../../slim-bindings/react-native"
+  },
+  "devDependencies": {
+    "playwright": "^1.61.1",
+    "typescript": "5.9.3",
+    "vite": "5.4.21"
+  }
+}

--- a/slim-cross-transport/package.json
+++ b/slim-cross-transport/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview --host 127.0.0.1"
   },
   "dependencies": {
-    "@agntcy/slim-bindings-react-native": "file:../../slim-bindings/react-native"
+    "@agntcy/slim-bindings-react-native": "2.0.0-alpha.7"
   },
   "devDependencies": {
     "playwright": "^1.61.1",

--- a/slim-cross-transport/scripts/browser-invite-smoke.mjs
+++ b/slim-cross-transport/scripts/browser-invite-smoke.mjs
@@ -1,0 +1,119 @@
+/**
+ * Two-browser-tab smoke: browser-a moderates, browser-b must accept invite.
+ */
+import { chromium } from "playwright";
+
+const URL = process.env.SMOKE_URL ?? "http://127.0.0.1:5173/";
+const SECRET = "test-shared-secret-value-0123456789abcdef";
+const MLS = process.env.SMOKE_MLS === "1";
+const INVITEES = (process.env.SMOKE_INVITEES ?? "org/default/browser-b")
+  .split(",")
+  .map((name) => name.trim())
+  .filter(Boolean);
+
+const browser = await chromium.launch({ headless: true });
+const ctxA = await browser.newContext();
+const ctxB = await browser.newContext();
+const pageA = await ctxA.newPage();
+const pageB = await ctxB.newPage();
+if (process.env.SMOKE_DEBUG === "1") {
+  pageA.on("console", (message) => console.log(`[browser-a:${message.type()}] ${message.text()}`));
+  pageB.on("console", (message) => console.log(`[browser-b:${message.type()}] ${message.text()}`));
+  pageA.on("pageerror", (error) => console.log(`[browser-a:error] ${error.stack ?? error}`));
+  pageB.on("pageerror", (error) => console.log(`[browser-b:error] ${error.stack ?? error}`));
+}
+
+async function waitWasm(page) {
+  await page.goto(URL, { waitUntil: "networkidle", timeout: 30_000 });
+  await page.waitForFunction(
+    () => document.getElementById("wasm-status")?.textContent?.includes("WASM ready"),
+    { timeout: 60_000 },
+  );
+}
+
+async function connect(page, { mode, localName }) {
+  await page.locator("#mode").selectOption(mode);
+  await page.fill("#local-name", localName);
+  await page.fill("#secret", SECRET);
+  await page.click("#connect");
+  await page.waitForFunction(
+    () => document.getElementById("conn-status")?.textContent?.includes("Connected"),
+    { timeout: 30_000 },
+  );
+}
+
+try {
+  await waitWasm(pageA);
+  await waitWasm(pageB);
+
+  await connect(pageB, { mode: "participant", localName: "org/default/browser-b" });
+  await connect(pageA, { mode: "moderator", localName: "org/default/browser-a" });
+  await pageA.waitForTimeout(500);
+
+  await pageA.locator("#mls-enabled").setChecked(MLS);
+  await pageA.fill("#channel", "org/default/room-1");
+  await pageA.fill("#invitees", INVITEES.join("\n"));
+
+  await pageA.click("#create-session");
+  try {
+    await pageA.waitForFunction(
+      (invitees) => {
+        const log = document.getElementById("log")?.textContent ?? "";
+        return invitees.every(
+          (name) => log.includes(`${name} joined`) || log.includes(`${name} did not join`),
+        );
+      },
+      INVITEES,
+      { timeout: 120_000 },
+    );
+  } catch {
+    console.log("=== browser-a log (moderator wait failed) ===");
+    console.log(await pageA.locator("#log").textContent());
+    console.log("=== browser-b log (moderator wait failed) ===");
+    console.log(await pageB.locator("#log").textContent());
+    throw new Error("moderator invite did not finish");
+  }
+
+  try {
+    await pageB.waitForFunction(
+      () => {
+        const count = document.getElementById("session-count")?.textContent ?? "0";
+        return Number(count) > 0;
+      },
+      { timeout: 60_000 },
+    );
+  } catch {
+    console.log("=== browser-a log (session wait failed) ===");
+    console.log(await pageA.locator("#log").textContent());
+    console.log("=== browser-b log (session wait failed) ===");
+    console.log(await pageB.locator("#log").textContent());
+    throw new Error("browser-b never received session card");
+  }
+
+  const logA = await pageA.locator("#log").textContent();
+  const logB = await pageB.locator("#log").textContent();
+  console.log("=== browser-a log ===");
+  console.log(logA);
+  console.log("=== browser-b log ===");
+  console.log(logB);
+
+  for (const invitee of INVITEES) {
+    if (!logA.includes(`${invitee} joined`)) {
+      console.error(`FAIL: moderator did not confirm ${invitee} joined`);
+      process.exit(1);
+    }
+  }
+  if (
+    INVITEES.includes("org/default/browser-b") &&
+    !logB.includes("accepted from a moderator")
+  ) {
+    console.error("FAIL: browser-b did not accept session");
+    process.exit(1);
+  }
+  console.log("BROWSER INVITE SMOKE PASSED");
+} catch (error) {
+  console.error("BROWSER INVITE SMOKE ERROR:", error);
+  process.exit(1);
+} finally {
+  await browser.close();
+}

--- a/slim-cross-transport/src/common.ts
+++ b/slim-cross-transport/src/common.ts
@@ -1,0 +1,120 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared SLIM browser (WASM) helpers aligned with
+ * slim-bindings/react-native/examples/browser/src/common.ts.
+ */
+
+import {
+  Direction,
+  Name,
+  Service,
+  uniffiInitAsync,
+  type AppLike,
+  type NameLike,
+  type ServiceLike,
+} from "@agntcy/slim-bindings-react-native/web";
+
+export const DEFAULT_ENDPOINT = "ws://127.0.0.1:46357";
+export const DEFAULT_SHARED_SECRET = "test-shared-secret-value-0123456789abcdef";
+
+let wasmReady = false;
+
+export function splitId(id: string): NameLike {
+  const parts = id.split("/");
+  if (parts.length !== 3) {
+    throw new Error(
+      `IDs must be in the format organization/namespace/app-or-stream, got: ${id}`,
+    );
+  }
+  return Name.fromString(id);
+}
+
+export async function initializeWasm(): Promise<void> {
+  if (wasmReady) return;
+  await uniffiInitAsync();
+  wasmReady = true;
+}
+
+export function isWasmReady(): boolean {
+  return wasmReady;
+}
+
+export type ConnectOptions = {
+  endpoint: string;
+  localId: string;
+  sharedSecret: string;
+  token?: string;
+};
+
+export type ConnectedApp = {
+  app: AppLike;
+  service: ServiceLike;
+  connId: bigint;
+};
+
+export async function createAndConnectApp(
+  options: ConnectOptions,
+): Promise<ConnectedApp> {
+  await initializeWasm();
+
+  const local = splitId(options.localId);
+  const serviceId = options.localId.replace(/[^A-Za-z0-9_-]/g, "-");
+  const service = new Service(serviceId);
+  const connId = await service.connectAsync(
+    options.endpoint.trim(),
+    options.token?.trim() || undefined,
+  );
+  const app = await service.createAppWithDirectionAsync(
+    local,
+    options.sharedSecret,
+    Direction.Bidirectional,
+  );
+  await app.subscribeAsync(local, connId);
+
+  return { app, service, connId };
+}
+
+export function describeError(error: unknown): string {
+  if (typeof error === "object" && error !== null) {
+    const uniffiError = error as {
+      tag?: unknown;
+      inner?: { message?: unknown };
+    };
+    if (typeof uniffiError.inner?.message === "string") {
+      const tag =
+        typeof uniffiError.tag === "string" ? `${uniffiError.tag}: ` : "";
+      return `${tag}${uniffiError.inner.message}`;
+    }
+  }
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.slice().buffer as ArrayBuffer;
+}
+
+/** Parse comma- or whitespace-separated invitee names. */
+export function parseInviteList(raw: string): string[] {
+  return raw
+    .split(/[\s,]+/)
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+export function parseInviteNames(raw: string, exclude?: string): NameLike[] {
+  const seen = new Set<string>();
+  const names: NameLike[] = [];
+  for (const value of parseInviteList(raw)) {
+    if (!value || value === exclude || seen.has(value)) continue;
+    seen.add(value);
+    names.push(splitId(value));
+  }
+  return names;
+}

--- a/slim-cross-transport/src/main.ts
+++ b/slim-cross-transport/src/main.ts
@@ -1,0 +1,368 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+import { SessionType } from "@agntcy/slim-bindings-react-native/web";
+import type {
+  AppLike,
+  NameLike,
+  ServiceLike,
+  SessionLike,
+} from "@agntcy/slim-bindings-react-native/web";
+
+import {
+  createAndConnectApp,
+  describeError,
+  initializeWasm,
+  parseInviteNames,
+  sleep,
+  splitId,
+} from "./common";
+import { logSessionSecurity } from "./session-common";
+import { SessionCard } from "./session-card";
+import "./style.css";
+
+function el<T extends HTMLElement>(id: string): T {
+  const node = document.getElementById(id);
+  if (!node) throw new Error(`missing #${id}`);
+  return node as T;
+}
+
+// --- DOM ---------------------------------------------------------------------
+const wasmStatus = el<HTMLSpanElement>("wasm-status");
+const connStatus = el<HTMLSpanElement>("conn-status");
+const modeSelect = el<HTMLSelectElement>("mode");
+const modeHint = el<HTMLParagraphElement>("mode-hint");
+const endpointInput = el<HTMLInputElement>("endpoint");
+const localNameInput = el<HTMLInputElement>("local-name");
+const secretInput = el<HTMLInputElement>("secret");
+const tokenInput = el<HTMLInputElement>("token");
+const connectBtn = el<HTMLButtonElement>("connect");
+const disconnectBtn = el<HTMLButtonElement>("disconnect");
+const autoAcceptInput = el<HTMLInputElement>("auto-accept");
+
+const sessionTypeInput = el<HTMLSelectElement>("session-type");
+const mlsInput = el<HTMLInputElement>("mls-enabled");
+const channelField = el<HTMLDivElement>("channel-field");
+const channelInput = el<HTMLInputElement>("channel");
+const inviteesField = el<HTMLDivElement>("invitees-field");
+const inviteesInput = el<HTMLTextAreaElement>("invitees");
+const destinationField = el<HTMLDivElement>("destination-field");
+const destinationInput = el<HTMLInputElement>("destination");
+const createBtn = el<HTMLButtonElement>("create-session");
+
+const sessionsEl = el<HTMLDivElement>("sessions");
+const sessionsEmpty = el<HTMLDivElement>("sessions-empty");
+const sessionCount = el<HTMLSpanElement>("session-count");
+const logEl = el<HTMLPreElement>("log");
+const clearLogBtn = el<HTMLButtonElement>("clear-log");
+
+// --- state -------------------------------------------------------------------
+let wasmReady = false;
+let app: AppLike | undefined;
+let service: ServiceLike | undefined;
+let connId: bigint | undefined;
+let localName = "";
+let listenAbort: AbortController | undefined;
+const cards = new Map<number, SessionCard>();
+let nextCardId = 1;
+
+const modeHints: Record<string, string> = {
+  moderator:
+    "Create sessions and invite participants by name. Enable auto-accept below if you also want to receive invitations.",
+  participant:
+    "Auto-accepts incoming sessions on connect. You can still create your own session to be in two at once.",
+};
+
+// --- helpers -----------------------------------------------------------------
+function log(message: string): void {
+  logEl.textContent += `[${new Date().toLocaleTimeString()}] ${message}\n`;
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+function logError(message: string, error: unknown): void {
+  log(`ERROR: ${message}: ${describeError(error)}`);
+  console.error(message, error);
+}
+
+function setConnectedUi(connected: boolean): void {
+  connectBtn.disabled = connected || !wasmReady;
+  disconnectBtn.disabled = !connected;
+  createBtn.disabled = !connected;
+  autoAcceptInput.disabled = !connected;
+  modeSelect.disabled = connected;
+  for (const input of [endpointInput, localNameInput, secretInput, tokenInput]) {
+    input.disabled = connected;
+  }
+}
+
+function updateComposerMode(): void {
+  const group = sessionTypeInput.value === "group";
+  channelField.hidden = !group;
+  inviteesField.hidden = !group;
+  destinationField.hidden = group;
+}
+
+function updateModeHint(): void {
+  modeHint.textContent = modeHints[modeSelect.value] ?? "";
+}
+
+function syncSessionsUi(): void {
+  sessionsEmpty.hidden = cards.size > 0;
+  sessionCount.textContent = String(cards.size);
+}
+
+function addCard(session: SessionLike, origin: "created" | "incoming"): SessionCard {
+  logSessionSecurity(session, log);
+  const card = new SessionCard({
+    id: nextCardId++,
+    session,
+    origin,
+    localName,
+    log,
+    logError,
+    onClose: (id) => void closeSession(id),
+    onInvite: (id, participant) => inviteToSession(id, participant),
+  });
+  cards.set(card.id, card);
+  sessionsEl.appendChild(card.element);
+  syncSessionsUi();
+  return card;
+}
+
+// --- core flow (mirrors examples/browser) ------------------------------------
+async function connect(): Promise<void> {
+  if (!wasmReady || app) return;
+  connectBtn.disabled = true;
+  connectBtn.textContent = "Connecting...";
+  try {
+    localName = localNameInput.value.trim();
+    const connected = await createAndConnectApp({
+      endpoint: endpointInput.value,
+      localId: localName,
+      sharedSecret: secretInput.value,
+      token: tokenInput.value.trim() || undefined,
+    });
+    app = connected.app;
+    service = connected.service;
+    connId = connected.connId;
+
+    const detail = ` (conn ${connId})`;
+    log(`Connected as ${app.name().toString()}${detail}`);
+    connStatus.textContent = `Connected${detail}`;
+    connStatus.className = "badge badge-ready";
+    setConnectedUi(true);
+
+    if (modeSelect.value === "participant") {
+      autoAcceptInput.checked = true;
+      startListening();
+    }
+  } catch (error) {
+    logError("Connection failed", error);
+    app = undefined;
+    service = undefined;
+    connId = undefined;
+    setConnectedUi(false);
+  } finally {
+    connectBtn.textContent = "Connect";
+  }
+}
+
+async function createSession(): Promise<void> {
+  const currentApp = app;
+  const currentConnId = connId;
+  if (!currentApp || currentConnId === undefined) return;
+
+  const group = sessionTypeInput.value === "group";
+  const mls = mlsInput.checked;
+  createBtn.disabled = true;
+  createBtn.textContent = "Creating...";
+  try {
+    const destination = splitId(
+      (group ? channelInput.value : destinationInput.value).trim(),
+    );
+    const invitees: NameLike[] = group
+      ? parseInviteNames(inviteesInput.value, localName)
+      : [destination];
+
+    for (const participant of invitees) {
+      await currentApp.setRouteAsync(participant, currentConnId);
+      log(`Route to ${participant.toString()} installed`);
+    }
+
+    const created = await currentApp.createSessionAndWaitAsync(
+      {
+        sessionType: group ? SessionType.Group : SessionType.PointToPoint,
+        maxRetries: 10,
+        interval: 1_000,
+        metadata: new Map([
+          ["demo", "slim-cross-transport"],
+          ["delivery", group ? "multicast" : "unicast"],
+          ["security", mls ? "mls" : "plaintext"],
+        ]),
+        mlsSettings: mls ? { headerIntegrityValidationPercent: 100 } : undefined,
+      },
+      destination,
+    );
+
+    await sleep(100);
+
+    const pendingId = nextCardId;
+    log(
+      `Session #${pendingId} created (${group ? "multicast" : "unicast"}, ${mls ? "MLS" : "no MLS"})`,
+    );
+
+    if (group) {
+      for (const participant of invitees) {
+        const label = participant.toString();
+        log(`Session #${pendingId}: inviting ${label}...`);
+        try {
+          await created.inviteAndWaitAsync(participant);
+          log(`Session #${pendingId}: ${label} joined`);
+        } catch (error) {
+          logError(
+            `Session #${pendingId}: ${label} did not join — check it is connected with this exact name and the same shared secret`,
+            error,
+          );
+        }
+      }
+    }
+
+    addCard(created, "created");
+  } catch (error) {
+    logError("Unable to create the session", error);
+    log("Check the endpoint, channel/remote name, and shared secret.");
+  } finally {
+    createBtn.textContent = "Create session";
+    createBtn.disabled = !app;
+  }
+}
+
+async function inviteToSession(id: number, participant: string): Promise<void> {
+  const currentApp = app;
+  const currentConnId = connId;
+  const card = cards.get(id);
+  if (!currentApp || currentConnId === undefined || !card) return;
+  const name = splitId(participant.trim());
+  await currentApp.setRouteAsync(name, currentConnId);
+  log(`Route to ${name.toString()} installed`);
+  await card.session.inviteAndWaitAsync(name);
+  log(`Session #${id}: ${name.toString()} joined`);
+}
+
+function startListening(): void {
+  const currentApp = app;
+  if (!currentApp || listenAbort) return;
+  const controller = new AbortController();
+  listenAbort = controller;
+  autoAcceptInput.checked = true;
+  log("Accepting incoming sessions...");
+
+  void (async () => {
+    const { signal } = controller;
+    while (app === currentApp && !signal.aborted) {
+      try {
+        const incoming = await currentApp.listenForSessionAsync(undefined, {
+          signal,
+        });
+        if (signal.aborted) break;
+        const card = addCard(incoming, "incoming");
+        log(`Session #${card.id} accepted from a moderator`);
+      } catch (error) {
+        if (!signal.aborted) logError("Incoming session listener stopped", error);
+        break;
+      }
+    }
+    if (listenAbort === controller) {
+      listenAbort = undefined;
+      autoAcceptInput.checked = false;
+    }
+  })();
+}
+
+function stopListening(): void {
+  listenAbort?.abort();
+  listenAbort = undefined;
+  autoAcceptInput.checked = false;
+}
+
+async function closeSession(id: number): Promise<void> {
+  const card = cards.get(id);
+  if (!card) return;
+  card.stop();
+  try {
+    await app?.deleteSessionAndWaitAsync(card.session);
+    log(`Session #${id} closed`);
+  } catch (error) {
+    logError(`Unable to close session #${id}`, error);
+  }
+  card.element.remove();
+  cards.delete(id);
+  syncSessionsUi();
+}
+
+async function disconnect(): Promise<void> {
+  stopListening();
+  const current = app;
+  const currentService = service;
+  const currentConnId = connId;
+  for (const card of [...cards.values()]) {
+    card.stop();
+    try {
+      await current?.deleteSessionAndWaitAsync(card.session);
+    } catch {
+      // best-effort cleanup
+    }
+    card.element.remove();
+  }
+  cards.clear();
+  syncSessionsUi();
+
+  if (currentService && currentConnId !== undefined) {
+    try {
+      currentService.disconnect(currentConnId);
+    } catch (error) {
+      logError("Disconnect failed", error);
+    }
+  }
+  app = undefined;
+  service = undefined;
+  connId = undefined;
+  log("Disconnected");
+  connStatus.textContent = "Disconnected";
+  connStatus.className = "badge badge-idle";
+  setConnectedUi(false);
+}
+
+// --- wiring ------------------------------------------------------------------
+modeSelect.addEventListener("change", updateModeHint);
+sessionTypeInput.addEventListener("change", updateComposerMode);
+connectBtn.addEventListener("click", () => void connect());
+disconnectBtn.addEventListener("click", () => void disconnect());
+createBtn.addEventListener("click", () => void createSession());
+autoAcceptInput.addEventListener("change", () => {
+  if (autoAcceptInput.checked) startListening();
+  else stopListening();
+});
+clearLogBtn.addEventListener("click", () => {
+  logEl.textContent = "";
+});
+window.addEventListener("pagehide", () => void disconnect());
+
+updateModeHint();
+updateComposerMode();
+setConnectedUi(false);
+
+void (async () => {
+  try {
+    await initializeWasm();
+    wasmReady = true;
+    wasmStatus.textContent = "WASM ready";
+    wasmStatus.className = "badge badge-ready";
+    connectBtn.disabled = false;
+    log("WASM bindings initialized");
+  } catch (error) {
+    wasmStatus.textContent = "WASM failed";
+    wasmStatus.className = "badge badge-error";
+    logError("Unable to initialize WASM bindings", error);
+  }
+})();

--- a/slim-cross-transport/src/session-card.ts
+++ b/slim-cross-transport/src/session-card.ts
@@ -1,0 +1,259 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+import { SessionType } from "@agntcy/slim-bindings-react-native/web";
+import type {
+  ReceivedMessage,
+  SessionLike,
+} from "@agntcy/slim-bindings-react-native/web";
+
+import { describeError, toArrayBuffer } from "./common";
+import {
+  isReceiveTimeout,
+  refreshSessionRoster,
+  startSessionParticipantPolling,
+} from "./session-common";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export type SessionOrigin = "created" | "incoming";
+
+export interface SessionCardDeps {
+  id: number;
+  session: SessionLike;
+  origin: SessionOrigin;
+  localName: string;
+  log: (message: string) => void;
+  logError: (message: string, error: unknown) => void;
+  onClose: (id: number) => void | Promise<void>;
+  /** Invite a new participant into this session (route + invite). */
+  onInvite?: (id: number, participant: string) => void | Promise<void>;
+}
+
+/**
+ * A single active session rendered as a card: its own receive loop, send box,
+ * participant roster, and transport/type/MLS badges. Several cards can be live
+ * at once for the same connected participant.
+ */
+export class SessionCard {
+  readonly id: number;
+  readonly element: HTMLElement;
+  readonly session: SessionLike;
+
+  private readonly deps: SessionCardDeps;
+  private readonly receiveAbort = new AbortController();
+  private readonly messagesEl: HTMLDivElement;
+  private readonly rosterEl: HTMLDivElement;
+  private stopParticipantPolling: (() => void) | undefined;
+  private stopped = false;
+
+  constructor(deps: SessionCardDeps) {
+    this.deps = deps;
+    this.id = deps.id;
+    this.session = deps.session;
+
+    const { element, messagesEl, rosterEl } = this.render();
+    this.element = element;
+    this.messagesEl = messagesEl;
+    this.rosterEl = rosterEl;
+
+    this.startReceiveLoop();
+    void this.refreshRoster();
+    this.stopParticipantPolling = startSessionParticipantPolling(
+      () => (this.stopped ? undefined : this.session),
+      this.rosterEl,
+      () => this.stopped,
+      this.deps.logError,
+    );
+  }
+
+  private render(): {
+    element: HTMLElement;
+    messagesEl: HTMLDivElement;
+    rosterEl: HTMLDivElement;
+  } {
+    const config = this.session.config();
+    const isGroup = config.sessionType === SessionType.Group;
+    const mls = Boolean(config.mlsSettings);
+
+    let title = "session";
+    try {
+      title = `${this.session.source().toString()} -> ${this.session
+        .destination()
+        .toString()}`;
+    } catch {
+      // Session accessors can throw if the session was already dropped.
+    }
+
+    const card = document.createElement("article");
+    card.className = "card";
+
+    const header = document.createElement("div");
+    header.className = "card-head";
+    header.innerHTML = `
+      <div class="card-title" title="${title}">${title}</div>
+      <div class="card-badges">
+        <span class="badge badge-ws">WebSocket</span>
+        <span class="badge ${isGroup ? "badge-group" : "badge-p2p"}">${isGroup ? "Multicast" : "Unicast"}</span>
+        <span class="badge ${mls ? "badge-mls" : "badge-plain"}">${mls ? "MLS" : "No MLS"}</span>
+        <span class="badge badge-origin">${this.deps.origin === "created" ? "moderator" : "invited"}</span>
+      </div>`;
+
+    const rosterEl = document.createElement("div");
+    rosterEl.className = "roster";
+    rosterEl.textContent = "participants: ...";
+
+    const canInvite =
+      this.deps.origin === "created" && isGroup && Boolean(this.deps.onInvite);
+    let inviteRow: HTMLFormElement | undefined;
+    if (canInvite) {
+      inviteRow = document.createElement("form");
+      inviteRow.className = "invite-row";
+      inviteRow.innerHTML = `
+        <input type="text" placeholder="Invite org/namespace/name" autocomplete="off" />
+        <button type="submit">Invite</button>`;
+      const inviteInput = inviteRow.querySelector("input") as HTMLInputElement;
+      const inviteButton = inviteRow.querySelector(
+        "button",
+      ) as HTMLButtonElement;
+      inviteRow.addEventListener("submit", (event) => {
+        event.preventDefault();
+        const name = inviteInput.value.trim();
+        if (!name) return;
+        void this.invite(name, inviteInput, inviteButton);
+      });
+    }
+
+    const messagesEl = document.createElement("div");
+    messagesEl.className = "messages";
+
+    const form = document.createElement("form");
+    form.className = "send-row";
+    form.innerHTML = `
+      <input type="text" placeholder="Message for this session" autocomplete="off" />
+      <button type="submit">Send</button>`;
+    const input = form.querySelector("input") as HTMLInputElement;
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const text = input.value.trim();
+      if (!text) return;
+      input.value = "";
+      void this.send(text);
+    });
+
+    const footer = document.createElement("div");
+    footer.className = "card-foot";
+    const closeButton = document.createElement("button");
+    closeButton.type = "button";
+    closeButton.className = "ghost small";
+    closeButton.textContent = "Close session";
+    closeButton.addEventListener("click", () => {
+      closeButton.disabled = true;
+      void this.deps.onClose(this.id);
+    });
+    footer.appendChild(closeButton);
+
+    if (inviteRow) {
+      card.append(header, rosterEl, inviteRow, messagesEl, form, footer);
+    } else {
+      card.append(header, rosterEl, messagesEl, form, footer);
+    }
+    return { element: card, messagesEl, rosterEl };
+  }
+
+  private async invite(
+    name: string,
+    input: HTMLInputElement,
+    button: HTMLButtonElement,
+  ): Promise<void> {
+    if (!this.deps.onInvite) return;
+    button.disabled = true;
+    try {
+      await this.deps.onInvite(this.id, name);
+      input.value = "";
+      await this.refreshRoster();
+    } catch (error) {
+      this.deps.logError(`Session #${this.id} invite failed`, error);
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  private startReceiveLoop(): void {
+    const { signal } = this.receiveAbort;
+    const currentSession = this.session;
+
+    void (async () => {
+      while (!this.stopped && !signal.aborted) {
+        try {
+          const received = await currentSession.getMessageAsync(1_000, {
+            signal,
+          });
+          if (!signal.aborted && !this.stopped) {
+            this.renderReceived(received);
+            void this.refreshRoster();
+          }
+        } catch (error) {
+          if (signal.aborted || this.stopped) return;
+          if (isReceiveTimeout(error)) continue;
+          this.deps.logError(
+            `Session #${this.id} receive loop stopped`,
+            error,
+          );
+          this.deps.log(`Session #${this.id} ended: ${describeError(error)}`);
+          return;
+        }
+      }
+    })();
+  }
+
+  private renderReceived(received: ReceivedMessage): void {
+    const source = received.context.sourceName.toString();
+    const text = decoder.decode(received.payload);
+    this.appendMessage(source, text, false);
+    this.deps.log(
+      `Session #${this.id}: received ${received.payload.byteLength} bytes from ${source}`,
+    );
+  }
+
+  private async send(text: string): Promise<void> {
+    try {
+      await this.session.publishAndWaitAsync(
+        toArrayBuffer(encoder.encode(text)),
+        "text/plain",
+        undefined,
+      );
+      this.appendMessage("you", text, true);
+    } catch (error) {
+      this.deps.logError(`Session #${this.id} publish failed`, error);
+    }
+  }
+
+  private appendMessage(source: string, text: string, mine: boolean): void {
+    const row = document.createElement("div");
+    row.className = `message ${mine ? "mine" : "theirs"}`;
+    const who = document.createElement("span");
+    who.className = "message-who";
+    who.textContent = source;
+    const body = document.createElement("span");
+    body.className = "message-body";
+    body.textContent = text;
+    row.append(who, body);
+    this.messagesEl.appendChild(row);
+    this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
+  }
+
+  private async refreshRoster(): Promise<void> {
+    if (this.stopped) return;
+    await refreshSessionRoster(this.session, this.rosterEl);
+  }
+
+  /** Stop the receive loop without touching the underlying session. */
+  stop(): void {
+    this.stopped = true;
+    this.stopParticipantPolling?.();
+    this.stopParticipantPolling = undefined;
+    this.receiveAbort.abort();
+  }
+}

--- a/slim-cross-transport/src/session-common.ts
+++ b/slim-cross-transport/src/session-common.ts
@@ -1,0 +1,68 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Session roster helpers aligned with
+ * slim-bindings/react-native/examples/browser/src/group-common.ts.
+ */
+
+import {
+  ParticipantStatus,
+  type SessionLike,
+} from "@agntcy/slim-bindings-react-native/web";
+
+import { describeError } from "./common";
+
+export function formatParticipantNames(
+  participants: Awaited<ReturnType<SessionLike["participantsListAsync"]>>,
+): string[] {
+  return participants.map((participant) => {
+    const name = participant.name.toString();
+    return participant.status === ParticipantStatus.Offline
+      ? `${name} (offline)`
+      : name;
+  });
+}
+
+export async function refreshSessionRoster(
+  session: SessionLike,
+  rosterEl: HTMLElement,
+  logError?: (message: string, error: unknown) => void,
+): Promise<void> {
+  try {
+    const participants = await session.participantsListAsync();
+    rosterEl.textContent = participants.length
+      ? `participants: ${formatParticipantNames(participants).join(", ")}`
+      : "participants: (none yet)";
+  } catch (error) {
+    rosterEl.textContent = "participants: (unavailable)";
+    logError?.("Failed to list participants", error);
+  }
+}
+
+export function logSessionSecurity(
+  session: SessionLike,
+  log: (message: string) => void,
+): void {
+  const security = session.config().mlsSettings ? "MLS" : "No MLS";
+  log(`Session security: ${security}`);
+}
+
+export function startSessionParticipantPolling(
+  getSession: () => SessionLike | undefined,
+  rosterEl: HTMLElement,
+  stopWhen: () => boolean,
+  logError?: (message: string, error: unknown) => void,
+): () => void {
+  const timer = window.setInterval(() => {
+    const session = getSession();
+    if (!session || stopWhen()) return;
+    void refreshSessionRoster(session, rosterEl, logError);
+  }, 3_000);
+
+  return () => window.clearInterval(timer);
+}
+
+export function isReceiveTimeout(error: unknown): boolean {
+  return describeError(error).toLowerCase().includes("timeout");
+}

--- a/slim-cross-transport/src/style.css
+++ b/slim-cross-transport/src/style.css
@@ -1,0 +1,443 @@
+/* Copyright AGNTCY Contributors (https://github.com/agntcy) */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+:root {
+  --bg: #0b1220;
+  --bg-soft: #121b2e;
+  --panel: #16213a;
+  --panel-2: #1c2946;
+  --border: #263450;
+  --text: #e8eefb;
+  --muted: #9fb0cd;
+  --accent: #4c8dff;
+  --accent-2: #7c5cff;
+  --ok: #2fbf71;
+  --warn: #fbaf46;
+  --danger: #ff6b6b;
+  --radius: 14px;
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(1200px 600px at 80% -10%, #1a2340 0%, transparent 60%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+#app {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 24px;
+  border-radius: var(--radius);
+  background: linear-gradient(120deg, var(--accent-2), var(--accent));
+  box-shadow: 0 12px 40px rgba(76, 141, 255, 0.25);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.brand-mark {
+  font-weight: 800;
+  letter-spacing: 2px;
+  font-size: 22px;
+  background: rgba(255, 255, 255, 0.18);
+  padding: 10px 14px;
+  border-radius: 12px;
+}
+
+.brand-text h1 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.brand-text p {
+  margin: 4px 0 0;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 13px;
+}
+
+.badges {
+  display: flex;
+  gap: 8px;
+}
+
+.badge {
+  font-size: 12px;
+  font-weight: 600;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.badge-idle {
+  background: rgba(255, 255, 255, 0.15);
+}
+.badge-wait {
+  background: var(--warn);
+  color: #1c1e21;
+}
+.badge-ready {
+  background: var(--ok);
+  color: #05130b;
+}
+.badge-error {
+  background: var(--danger);
+  color: #1c0505;
+}
+.badge-ws {
+  background: rgba(76, 141, 255, 0.2);
+  border-color: var(--accent);
+  color: #cfe1fb;
+}
+.badge-group {
+  background: rgba(124, 92, 255, 0.2);
+  border-color: var(--accent-2);
+  color: #ddd4ff;
+}
+.badge-p2p {
+  background: rgba(159, 176, 205, 0.15);
+  border-color: var(--muted);
+  color: var(--muted);
+}
+.badge-mls {
+  background: rgba(47, 191, 113, 0.18);
+  border-color: var(--ok);
+  color: #b6f0d0;
+}
+.badge-plain {
+  background: rgba(251, 175, 70, 0.15);
+  border-color: var(--warn);
+  color: #ffe0b0;
+}
+.badge-origin {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--muted);
+}
+
+.layout {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  gap: 18px;
+  align-items: start;
+}
+
+.col {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px;
+}
+
+.panel h2 {
+  margin: 0 0 12px;
+  font-size: 15px;
+  letter-spacing: 0.3px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.step {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: linear-gradient(120deg, var(--accent), var(--accent-2));
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.panel-head h2 {
+  margin: 0;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 12.5px;
+  line-height: 1.5;
+  margin: 0 0 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.field label {
+  font-size: 12px;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+input[type="text"],
+select,
+textarea {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text);
+  padding: 9px 11px;
+  font-size: 13px;
+  font-family: inherit;
+  width: 100%;
+}
+
+textarea {
+  resize: vertical;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(76, 141, 255, 0.2);
+}
+
+input:disabled,
+select:disabled,
+textarea:disabled {
+  opacity: 0.6;
+}
+
+.row {
+  display: flex;
+  gap: 10px;
+}
+
+button {
+  background: linear-gradient(120deg, var(--accent), var(--accent-2));
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.05s ease, opacity 0.15s ease;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+button.ghost {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+
+button.small {
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--muted);
+  margin-top: 10px;
+  cursor: pointer;
+}
+
+.toggle input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+}
+
+.pill {
+  background: var(--accent);
+  color: #04122b;
+  font-weight: 700;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 12px;
+}
+
+.sessions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 14px;
+}
+
+.empty-state {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 13px;
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  padding: 28px;
+  text-align: center;
+}
+
+.card {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 260px;
+}
+
+.card-head {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.card-title {
+  font-size: 12.5px;
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.card-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.roster {
+  font-size: 11.5px;
+  color: var(--muted);
+  word-break: break-word;
+}
+
+.messages {
+  flex: 1;
+  min-height: 90px;
+  max-height: 220px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--bg-soft);
+  border-radius: 10px;
+  padding: 8px;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 90%;
+  padding: 6px 9px;
+  border-radius: 10px;
+  font-size: 12.5px;
+}
+
+.message.mine {
+  align-self: flex-end;
+  background: linear-gradient(120deg, var(--accent), var(--accent-2));
+  color: #fff;
+}
+
+.message.theirs {
+  align-self: flex-start;
+  background: var(--panel);
+  border: 1px solid var(--border);
+}
+
+.message-who {
+  font-size: 10.5px;
+  opacity: 0.8;
+  font-weight: 600;
+}
+
+.send-row,
+.invite-row {
+  display: flex;
+  gap: 8px;
+}
+
+.send-row input,
+.invite-row input {
+  flex: 1;
+}
+
+.invite-row button {
+  background: transparent;
+  border: 1px solid var(--accent-2);
+  color: #ddd4ff;
+}
+
+.invite-row button:hover:not(:disabled) {
+  background: rgba(124, 92, 255, 0.18);
+}
+
+.card-foot {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.log {
+  background: #060b16;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px;
+  font-family: "SFMono-Regular", ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  color: #b9c7e2;
+  max-height: 260px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}

--- a/slim-cross-transport/tsconfig.json
+++ b/slim-cross-transport/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "useDefineForClassFields": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/slim-cross-transport/vite.config.ts
+++ b/slim-cross-transport/vite.config.ts
@@ -1,0 +1,23 @@
+import { fileURLToPath, URL } from "node:url";
+
+import { defineConfig } from "vite";
+
+// Setting server.fs.allow replaces Vite's default list, so include both this
+// project and the sibling slim-bindings checkout (WASM lives outside node_modules).
+const projectRoot = fileURLToPath(new URL(".", import.meta.url));
+const bindingsRoot = fileURLToPath(
+  new URL("../../slim-bindings/react-native", import.meta.url),
+);
+
+export default defineConfig({
+  build: {
+    target: "es2022",
+  },
+  server: {
+    fs: {
+      allow: [projectRoot, bindingsRoot],
+    },
+    port: 5173,
+    strictPort: true,
+  },
+});

--- a/slim-cross-transport/vite.config.ts
+++ b/slim-cross-transport/vite.config.ts
@@ -1,23 +1,31 @@
-import { fileURLToPath, URL } from "node:url";
-
 import { defineConfig } from "vite";
-
-// Setting server.fs.allow replaces Vite's default list, so include both this
-// project and the sibling slim-bindings checkout (WASM lives outside node_modules).
-const projectRoot = fileURLToPath(new URL(".", import.meta.url));
-const bindingsRoot = fileURLToPath(
-  new URL("../../slim-bindings/react-native", import.meta.url),
-);
 
 export default defineConfig({
   build: {
     target: "es2022",
   },
+  assetsInclude: ["**/*.wasm"],
+  optimizeDeps: {
+    // Pre-bundling rewrites the relative WASM URL in web.ts to a path under
+    // node_modules/.vite/deps/ that does not exist, so the browser receives
+    // index.html instead of the binary.
+    exclude: ["@agntcy/slim-bindings-react-native"],
+  },
   server: {
-    fs: {
-      allow: [projectRoot, bindingsRoot],
-    },
     port: 5173,
     strictPort: true,
   },
+  plugins: [
+    {
+      name: "wasm-mime-type",
+      configureServer(server) {
+        server.middlewares.use((req, res, next) => {
+          if (req.url?.includes(".wasm")) {
+            res.setHeader("Content-Type", "application/wasm");
+          }
+          next();
+        });
+      },
+    },
+  ],
 });


### PR DESCRIPTION
## Summary

Adds **slim-cross-transport**, a reference demo in `agentic-apps` that shows SLIM messaging across **WebSocket and gRPC** on a single dual-transport node. Browser participants use `@agntcy/slim-bindings-react-native` WASM bindings; native Rust clients join over WebSocket and gRPC.

- **Browser UI** — multi-session Vite app (moderator + participants, multicast/unicast, optional MLS)
- **Bindings integration** — links to sibling `slim-bindings/react-native` (manual WASM build; not on npm yet)
- **API alignment** — uses the latest Service-based browser API from `slim-bindings/react-native/examples/browser` (`createAndConnectApp`, `setRouteAsync`, `service.disconnect`, etc.)
- **Orchestration** — `Taskfile.yaml` for the SLIM node, four native clients, WASM build, and UI

## What’s included

| Component | Description |
|-----------|-------------|
| `slim-cross-transport/` | Browser demo + SLIM node/client configs |
| `src/common.ts` | Shared connect/helpers (mirrors browser examples) |
| `src/session-common.ts` | Participant roster + polling helpers |
| `configs/` | Dual-transport node (`:46357` ws, `:46358` grpc) + native client configs |
| `scripts/browser-invite-smoke.mjs` | Playwright smoke test for browser invite flow |

## Test plan

- [ ] Clone `agentic-apps`, `slim`, and `slim-bindings` as siblings
- [ ] Build browser WASM: `cd slim-bindings/react-native && npm run build:web`
- [ ] Install demo deps: `cd agentic-apps/slim-cross-transport && npm install`
- [ ] Start SLIM node: `task node`
- [ ] Start native clients: `task native:grpc-1`, `native:grpc-2`, `native:ws-1`, `native:ws-2`
- [ ] Start UI: `task ui` → open http://127.0.0.1:5173/
- [ ] Connect three browser tabs (moderator + 2 participants)
- [ ] Create a multicast session inviting `browser-b`, `native-ws-1`, `native-grpc-1`
- [ ] Confirm messages reach browser and native terminals
- [ ] Optional: run Playwright smoke — `node scripts/browser-invite-smoke.mjs` (with UI running)