### PR TITLE
chore: update SLIM browser bindings to 2.0.0

### DIFF
--- a/slim-cross-transport/README.md
+++ b/slim-cross-transport/README.md
@@ -33,7 +33,7 @@ node config: WebSocket on `:46357` and gRPC on `:46358`.
 ```
 
 The browser UI depends on
-[`@agntcy/slim-bindings-react-native@2.0.0-alpha.7`](https://www.npmjs.com/package/@agntcy/slim-bindings-react-native/v/2.0.0-alpha.7).
+[`@agntcy/slim-bindings-react-native@2.0.0`](https://www.npmjs.com/package/@agntcy/slim-bindings-react-native/v/2.0.0).
 The `/web` entry point and prebuilt `index_bg.wasm` ship in that package.
 
 ---
@@ -77,7 +77,7 @@ cd ~/slim-workspace/agentic-apps/slim-cross-transport
 npm install
 ```
 
-This pulls [`@agntcy/slim-bindings-react-native@2.0.0-alpha.7`](https://www.npmjs.com/package/@agntcy/slim-bindings-react-native/v/2.0.0-alpha.7) from npm, including the browser WASM binary.
+This pulls [`@agntcy/slim-bindings-react-native@2.0.0`](https://www.npmjs.com/package/@agntcy/slim-bindings-react-native/v/2.0.0) from npm, including the browser WASM binary.
 
 **Optional — confirm WASM is present:**
 

--- a/slim-cross-transport/Taskfile.yaml
+++ b/slim-cross-transport/Taskfile.yaml
@@ -13,7 +13,7 @@ silent: true
 #   <root>/slim  - the SLIM core repo (provides `slim` and `client` bins)
 #
 # Browser WASM bindings come from npm:
-#   @agntcy/slim-bindings-react-native@2.0.0-alpha.7
+#   @agntcy/slim-bindings-react-native@2.0.0
 
 vars:
   SLIM_DIR: "{{.TASKFILE_DIR}}/../../slim"

--- a/slim-cross-transport/package-lock.json
+++ b/slim-cross-transport/package-lock.json
@@ -8,7 +8,7 @@
       "name": "slim-cross-transport",
       "version": "0.1.0",
       "dependencies": {
-        "@agntcy/slim-bindings-react-native": "2.0.0-alpha.7"
+        "@agntcy/slim-bindings-react-native": "2.0.0"
       },
       "devDependencies": {
         "playwright": "^1.61.1",
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@agntcy/slim-bindings-react-native": {
-      "version": "2.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@agntcy/slim-bindings-react-native/-/slim-bindings-react-native-2.0.0-alpha.7.tgz",
-      "integrity": "sha512-oZEB3kJ5rPlbb851cJzgYfRixt86QuXIElalIUMNeooIZhhkLa4Es41NE8Trg6aSTI/L3AoxlqP877V3HTejpA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@agntcy/slim-bindings-react-native/-/slim-bindings-react-native-2.0.0.tgz",
+      "integrity": "sha512-r5nVDc4T6ouBlWx214FHqtHnDA7uhFfZKXEA22+hK2xYpw6hCpgr52rn15fX2AEdfIIzyrEUhMSj/gTV5zPmiw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ubjs/core": "0.31.0-3",

--- a/slim-cross-transport/package.json
+++ b/slim-cross-transport/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview --host 127.0.0.1"
   },
   "dependencies": {
-    "@agntcy/slim-bindings-react-native": "2.0.0-alpha.7"
+    "@agntcy/slim-bindings-react-native": "2.0.0"
   },
   "devDependencies": {
     "playwright": "^1.61.1",


### PR DESCRIPTION
## Summary
- Update `@agntcy/slim-bindings-react-native` from `2.0.0-alpha.7` to stable `2.0.0`
- Refresh the npm lockfile
- Update README and Taskfile version references
## Validation
- [x] `npm run build`
- [x] Browser WASM initialized successfully
- [x] Browser participant connected to the local SLIM node over WebSocket
- [x] No remaining `2.0.0-alpha.7` references in `slim-cross-transport`