### PR TITLE
fix: pin NLTK path security fixes

### DIFF
--- a/network_of_assistants/pyproject.toml
+++ b/network_of_assistants/pyproject.toml
@@ -10,3 +10,10 @@ members = ["noa-file-assistant", "noa-slim", "noa-user-proxy", "noa-moderator", 
 
 [dependency-groups]
 dev = ["ruff<1.0.0,>=0.9.3"]
+
+# NLTK has no released fix yet for GHSA-8mgp-746c-j5xp. Use the upstream
+# develop commit containing the pathsec fixes until the patched release ships.
+[tool.uv]
+override-dependencies = [
+    "nltk @ git+https://github.com/nltk/nltk.git@c06cd2645e3116156466bece11a9eb989c04afae",
+]

--- a/network_of_assistants/uv.lock
+++ b/network_of_assistants/uv.lock
@@ -16,6 +16,7 @@ members = [
     "noa-web-surfer",
     "slim",
 ]
+overrides = [{ name = "nltk", git = "https://github.com/nltk/nltk.git?rev=c06cd2645e3116156466bece11a9eb989c04afae" }]
 
 [[package]]
 name = "aiofiles"
@@ -1711,17 +1712,13 @@ wheels = [
 [[package]]
 name = "nltk"
 version = "3.10.3"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/nltk/nltk.git?rev=c06cd2645e3116156466bece11a9eb989c04afae#c06cd2645e3116156466bece11a9eb989c04afae" }
 dependencies = [
     { name = "click" },
     { name = "defusedxml" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pin the transitive NLTK dependency to upstream commit `c06cd2645e3116156466bece11a9eb989c04afae`, which contains the pathsec fixes for GHSA-8mgp-746c-j5xp / CVE-2026-81726.
- Keep the lockfile reproducible until NLTK publishes a patched release.

## Validation
- `uv lock --check` passed.
- Verified the installed NLTK source is the pinned commit and that TransitionParser and AveragedPerceptron model paths use pathsec guards.
- `pip-audit` reports no findings other than the advisory being addressed by the unreleased upstream source fix.
- NoA web-surfer import smoke test passed.